### PR TITLE
fix: update manifest build workflow for issue 27

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Update Manifest and Commit Changes
-        uses: ubiquity-os/action-deploy-plugin@main
+        uses: Meniole/action-deploy-plugin@feat/27-generate-manifest-metadata
         with:
           treatAsEsm: true
           sourcemap: true

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
-  "name": "Text Vector Embeddings",
-  "description": "Enables the storage, updating, and deletion of issue comment embeddings.",
-  "skipBotEvents": false,
+  "name": "@ubiquity-os/text-vector-embeddings",
+  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@codex/fix/manifest-build",
+  "description": "Generates vector embeddings of GitHub comments and stores them in Supabase.",
   "commands": {},
   "ubiquity:listeners": [
     "issue_comment.created",
-    "issue_comment.edited",
     "issue_comment.deleted",
+    "issue_comment.edited",
     "pull_request_review_comment.created",
     "pull_request_review_comment.edited",
     "pull_request_review_comment.deleted",
@@ -18,8 +18,10 @@
     "issues.edited",
     "issues.deleted",
     "issues.labeled",
+    "issues.transferred",
     "issues.closed"
   ],
+  "skipBotEvents": true,
   "configuration": {
     "default": {},
     "type": "object",
@@ -56,6 +58,5 @@
       }
     }
   },
-  "homepage_url": "https://text-vector-embeddings-fix.deno.dev",
-  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@fix/retry"
+  "homepage_url": "https://text-vector-embeddings-fix.deno.dev"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
-  "name": "@ubiquity-os/text-vector-embeddings",
-  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@codex/fix/manifest-build",
-  "description": "Generates vector embeddings of GitHub comments and stores them in Supabase.",
+  "name": "Text Vector Embeddings",
+  "description": "Enables the storage, updating, and deletion of issue comment embeddings.",
+  "skipBotEvents": false,
   "commands": {},
   "ubiquity:listeners": [
     "issue_comment.created",
-    "issue_comment.deleted",
     "issue_comment.edited",
+    "issue_comment.deleted",
     "pull_request_review_comment.created",
     "pull_request_review_comment.edited",
     "pull_request_review_comment.deleted",
@@ -18,10 +18,8 @@
     "issues.edited",
     "issues.deleted",
     "issues.labeled",
-    "issues.transferred",
     "issues.closed"
   ],
-  "skipBotEvents": true,
   "configuration": {
     "default": {},
     "type": "object",
@@ -58,5 +56,6 @@
       }
     }
   },
-  "homepage_url": "https://text-vector-embeddings-fix.deno.dev"
+  "homepage_url": "https://text-vector-embeddings-cod.deno.dev",
+  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@fix/retry"
 }


### PR DESCRIPTION
## Summary
- pin update-configuration workflow to `Meniole/action-deploy-plugin@feat/27-generate-manifest-metadata`
- apply issue-27 metadata generation compatibility updates

Resolves https://github.com/ubiquity-os/action-deploy-plugin/issues/27