### PR TITLE
fix: sync manifest workflow metadata for issue 27

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -17,6 +17,7 @@ jobs:
           treatAsEsm: true
           sourcemap: true
           pluginEntry: ${{ github.workspace }}/src/main.ts
+          skipBotEvents: false
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -18,6 +18,7 @@ jobs:
           sourcemap: true
           pluginEntry: ${{ github.workspace }}/src/main.ts
           skipBotEvents: false
+          excludeSupportedEvents: "issue_comment.created"
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Update Manifest and Commit Changes
-        uses: ubiquity-os/action-deploy-plugin@main
+        uses: Meniole/action-deploy-plugin@feat/27-generate-manifest-metadata
         with:
           treatAsEsm: true
           sourcemap: true

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,11 @@
 {
-  "name": "Text Vector Embeddings",
-  "description": "Enables the storage, updating, and deletion of issue comment embeddings.",
-  "skipBotEvents": false,
+  "name": "@ubiquity-os/text-vector-embeddings",
+  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@codex/fix/manifest-build-issue-comment-embeddings-issue-comment-embeddings-u2",
+  "description": "Generates vector embeddings of GitHub comments and stores them in Supabase.",
   "commands": {},
   "ubiquity:listeners": [
-    "issue_comment.created",
-    "issue_comment.edited",
     "issue_comment.deleted",
+    "issue_comment.edited",
     "pull_request_review_comment.created",
     "pull_request_review_comment.edited",
     "pull_request_review_comment.deleted",
@@ -18,8 +17,10 @@
     "issues.edited",
     "issues.deleted",
     "issues.labeled",
+    "issues.transferred",
     "issues.closed"
   ],
+  "skipBotEvents": false,
   "configuration": {
     "default": {},
     "type": "object",
@@ -56,6 +57,5 @@
       }
     }
   },
-  "homepage_url": "https://text-vector-embeddings-fix.deno.dev",
-  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@fix/retry"
+  "homepage_url": "https://text-vector-embeddings-fix.deno.dev"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,12 @@
 {
-  "name": "@ubiquity-os/text-vector-embeddings",
-  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@codex/fix/manifest-build-issue-comment-embeddings-issue-comment-embeddings-u2",
-  "description": "Generates vector embeddings of GitHub comments and stores them in Supabase.",
+  "name": "Text Vector Embeddings",
+  "description": "Enables the storage, updating, and deletion of issue comment embeddings.",
+  "skipBotEvents": false,
   "commands": {},
   "ubiquity:listeners": [
-    "issue_comment.deleted",
+    "issue_comment.created",
     "issue_comment.edited",
+    "issue_comment.deleted",
     "pull_request_review_comment.created",
     "pull_request_review_comment.edited",
     "pull_request_review_comment.deleted",
@@ -17,10 +18,8 @@
     "issues.edited",
     "issues.deleted",
     "issues.labeled",
-    "issues.transferred",
     "issues.closed"
   ],
-  "skipBotEvents": false,
   "configuration": {
     "default": {},
     "type": "object",
@@ -57,5 +56,6 @@
       }
     }
   },
-  "homepage_url": "https://text-vector-embeddings-fix.deno.dev"
+  "homepage_url": "https://text-vector-embeddings-cod.deno.dev",
+  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@fix/retry"
 }

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,10 +1,14 @@
 import { StaticDecode, Type as T } from "@sinclair/typebox";
 
 const annotateCommandSchema = T.Object({
-  name: T.Literal("annotate"),
+  name: T.Literal("annotate", { description: "Annotate an issue or pull request with vector metadata.", examples: ["/annotate"] }),
   parameters: T.Object({
-    commentUrl: T.Optional(T.String()),
-    scope: T.Optional(T.Union([T.Literal("global"), T.Literal("org"), T.Literal("repo")])),
+    commentUrl: T.Optional(
+      T.String({ description: "Comment URL to use as annotation source.", examples: ["https://github.com/owner/repo/issues/1#issuecomment-1"] })
+    ),
+    scope: T.Optional(
+      T.Union([T.Literal("global"), T.Literal("org"), T.Literal("repo")], { description: "Scope where the annotation applies.", examples: ["repo"] })
+    ),
   }),
 });
 


### PR DESCRIPTION
## Summary
- update deploy action pin and manifest generation inputs
- propagate `skipBotEvents` from `manifest.json` into workflow inputs when set
- add missing TypeBox command parameter descriptions/examples

Resolves https://github.com/ubiquity-os/action-deploy-plugin/issues/27