### PR TITLE
feat: add private repo redact switch for stored content

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Cron GitHub App auth:
     dedupeWarningThreshold: 0.75
     annotateThreshold: 0.65
     jobMatchingThreshold: 0.75
+    redactPrivateRepoComments: false
 ```
 
 ## Recommendations

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
-  "name": "Text Vector Embeddings",
-  "description": "Enables the storage, updating, and deletion of issue comment embeddings.",
-  "skipBotEvents": false,
+  "name": "@ubiquity-os/text-vector-embeddings",
+  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@codex/issue-23-redact-switch",
+  "description": "Generates vector embeddings of GitHub comments and stores them in Supabase.",
   "commands": {},
   "ubiquity:listeners": [
     "issue_comment.created",
-    "issue_comment.edited",
     "issue_comment.deleted",
+    "issue_comment.edited",
     "pull_request_review_comment.created",
     "pull_request_review_comment.edited",
     "pull_request_review_comment.deleted",
@@ -18,8 +18,10 @@
     "issues.edited",
     "issues.deleted",
     "issues.labeled",
+    "issues.transferred",
     "issues.closed"
   ],
+  "skipBotEvents": true,
   "configuration": {
     "default": {},
     "type": "object",
@@ -53,9 +55,13 @@
         "default": false,
         "description": "When true, disables storing issues and comments in the database.",
         "type": "boolean"
+      },
+      "redactPrivateRepoComments": {
+        "default": false,
+        "description": "When true, redact markdown and payload content for private repositories before persisting.",
+        "type": "boolean"
       }
     }
   },
-  "homepage_url": "https://text-vector-embeddings-dev.deno.dev",
-  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@fix/retry"
+  "homepage_url": "https://text-vector-embeddings-dev.deno.dev"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
-  "name": "@ubiquity-os/text-vector-embeddings",
-  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@codex/issue-23-redact-switch",
-  "description": "Generates vector embeddings of GitHub comments and stores them in Supabase.",
+  "name": "Text Vector Embeddings",
+  "description": "Enables the storage, updating, and deletion of issue comment embeddings.",
+  "skipBotEvents": false,
   "commands": {},
   "ubiquity:listeners": [
     "issue_comment.created",
-    "issue_comment.deleted",
     "issue_comment.edited",
+    "issue_comment.deleted",
     "pull_request_review_comment.created",
     "pull_request_review_comment.edited",
     "pull_request_review_comment.deleted",
@@ -18,10 +18,8 @@
     "issues.edited",
     "issues.deleted",
     "issues.labeled",
-    "issues.transferred",
     "issues.closed"
   ],
-  "skipBotEvents": false,
   "configuration": {
     "default": {},
     "type": "object",
@@ -55,13 +53,9 @@
         "default": false,
         "description": "When true, disables storing issues and comments in the database.",
         "type": "boolean"
-      },
-      "redactPrivateRepoComments": {
-        "default": false,
-        "description": "When true, redact markdown and payload content for private repositories before persisting.",
-        "type": "boolean"
       }
     }
   },
-  "homepage_url": "https://text-vector-embeddings-dev.deno.dev"
+  "homepage_url": "https://text-vector-embeddings-cod.deno.dev",
+  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@fix/retry"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
-  "name": "Text Vector Embeddings",
-  "description": "Enables the storage, updating, and deletion of issue comment embeddings.",
-  "skipBotEvents": false,
+  "name": "@ubiquity-os/text-vector-embeddings",
+  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@codex/issue-23-redact-switch",
+  "description": "Generates vector embeddings of GitHub comments and stores them in Supabase.",
   "commands": {},
   "ubiquity:listeners": [
     "issue_comment.created",
-    "issue_comment.edited",
     "issue_comment.deleted",
+    "issue_comment.edited",
     "pull_request_review_comment.created",
     "pull_request_review_comment.edited",
     "pull_request_review_comment.deleted",
@@ -18,8 +18,10 @@
     "issues.edited",
     "issues.deleted",
     "issues.labeled",
+    "issues.transferred",
     "issues.closed"
   ],
+  "skipBotEvents": false,
   "configuration": {
     "default": {},
     "type": "object",
@@ -53,9 +55,13 @@
         "default": false,
         "description": "When true, disables storing issues and comments in the database.",
         "type": "boolean"
+      },
+      "redactPrivateRepoComments": {
+        "default": false,
+        "description": "When true, redact markdown and payload content for private repositories before persisting.",
+        "type": "boolean"
       }
     }
   },
-  "homepage_url": "https://text-vector-embeddings-cod.deno.dev",
-  "short_name": "ubiquity-os-marketplace/text-vector-embeddings@fix/retry"
+  "homepage_url": "https://text-vector-embeddings-cod.deno.dev"
 }

--- a/src/handlers/add-comments.ts
+++ b/src/handlers/add-comments.ts
@@ -3,6 +3,7 @@ import { addIssue } from "./add-issue";
 import { removeAnnotateFootnotes } from "./annotate";
 import { ensurePullRequestIssue } from "./pull-request-review-utils";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 
 export async function addComments(context: Context<"issue_comment.created">) {
   const {
@@ -15,7 +16,7 @@ export async function addComments(context: Context<"issue_comment.created">) {
   const markdown = comment.body;
   const authorId = comment.user?.id || -1;
   const id = comment.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
   const isPullRequestComment = !!payload.issue.pull_request;
   let issueId = payload.issue.node_id;
 

--- a/src/handlers/add-issue.ts
+++ b/src/handlers/add-issue.ts
@@ -1,6 +1,7 @@
 import { Context } from "../types/index";
 import { cleanContent } from "./issue-deduplication";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 
 export async function addIssue(context: Context<"issues.opened" | "issue_comment.created" | "issue_comment.edited">) {
   const {
@@ -15,7 +16,7 @@ export async function addIssue(context: Context<"issues.opened" | "issue_comment
   let markdown = payload.issue.body && payload.issue.title ? `${payload.issue.body} ${payload.issue.title}` : null;
   const authorId = issue.user?.id || -1;
   const id = issue.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
 
   if (!isHumanAuthor) {
     logger.debug("Issue author is not human; storing issue without embeddings.", {

--- a/src/handlers/add-pull-request-review.ts
+++ b/src/handlers/add-pull-request-review.ts
@@ -1,5 +1,6 @@
 import { Context } from "../types/index";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 import { removeAnnotateFootnotes } from "./annotate";
 import { buildPullRequestReviewMarkdown, ensurePullRequestIssue } from "./pull-request-review-utils";
 
@@ -49,7 +50,7 @@ export async function addPullRequestReview(context: Context<"pull_request_review
         id: review.node_id ?? `${review.id}`,
         author_id: review.user?.id ?? -1,
         payload,
-        isPrivate: payload.repository.private,
+        isPrivate: shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments),
         issue_id: issueId ?? pullRequest.node_id ?? null,
         docType: "pull_request_review",
       },

--- a/src/handlers/add-pull-request.ts
+++ b/src/handlers/add-pull-request.ts
@@ -1,6 +1,7 @@
 import { Context } from "../types/index";
 import { cleanContent } from "./issue-deduplication";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 import { buildPullRequestMarkdown } from "./pull-request-review-utils";
 
 export async function addPullRequest(context: Context<"pull_request.opened">) {
@@ -16,7 +17,7 @@ export async function addPullRequest(context: Context<"pull_request.opened">) {
   const markdown = isHumanAuthor ? buildPullRequestMarkdown(pullRequest) : null;
   const authorId = pullRequest.user?.id || -1;
   const id = pullRequest.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
 
   if (!isHumanAuthor) {
     logger.debug("Pull request author is not human; storing PR without embeddings.", {

--- a/src/handlers/add-review-comments.ts
+++ b/src/handlers/add-review-comments.ts
@@ -1,5 +1,6 @@
 import { Context } from "../types/index";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 import { removeAnnotateFootnotes } from "./annotate";
 import { buildReviewCommentMarkdown, ensurePullRequestIssue, fetchParentReviewComment, formatReviewThreadContext } from "./pull-request-review-utils";
 
@@ -14,7 +15,7 @@ export async function addReviewComment(context: Context<"pull_request_review_com
   const markdown = comment.body;
   const authorId = comment.user?.id || -1;
   const id = comment.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
   const pullRequest = payload.pull_request;
 
   const isHumanAuthor = comment.user?.type === "User";

--- a/src/handlers/complete-issue.ts
+++ b/src/handlers/complete-issue.ts
@@ -1,12 +1,14 @@
 import { Context } from "../types/index";
 import { cleanContent } from "./issue-deduplication";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 
 export async function completeIssue(context: Context<"issues.closed">) {
   const {
     logger,
     adapters: { supabase, kv },
     payload,
+    config,
   } = context;
 
   // Only handle issues closed as completed
@@ -22,7 +24,7 @@ export async function completeIssue(context: Context<"issues.closed">) {
   }
 
   const id = payload.issue.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
   const authorType = payload.issue.user?.type;
   const isHumanAuthor = authorType === "User";
   let markdown = payload.issue.body && payload.issue.title ? payload.issue.body + " " + payload.issue.title : null;

--- a/src/handlers/pull-request-review-utils.ts
+++ b/src/handlers/pull-request-review-utils.ts
@@ -1,5 +1,6 @@
 import { Context } from "../types/index";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 import { removeAnnotateFootnotes } from "./annotate";
 
 type PullRequestContext = Context;
@@ -203,7 +204,7 @@ export async function ensurePullRequestIssue(context: PullRequestContext, pullRe
   }
 
   const authorId = pullRequest.user?.id ?? -1;
-  const isPrivate = payload.repository?.private ?? false;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository?.private ?? false, config.redactPrivateRepoComments);
   const queueSettings = getEmbeddingQueueSettings(context.env);
 
   await supabase.issue.createIssue(

--- a/src/handlers/transfer-issue.ts
+++ b/src/handlers/transfer-issue.ts
@@ -1,10 +1,12 @@
 import { Context } from "../types/index";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 
 export async function issueTransfer(context: Context<"issues.transferred">) {
   const {
     logger,
     adapters: { supabase, kv },
+    config,
   } = context;
   const { changes, issue } = context.payload;
   const nodeId = issue.node_id;
@@ -16,7 +18,7 @@ export async function issueTransfer(context: Context<"issues.transferred">) {
   const markdownParts = [new_issue.body?.trim() ?? "", new_issue.title?.trim() ?? ""].filter(Boolean);
   let markdown = markdownParts.length > 0 ? markdownParts.join(" ") : null;
   const authorId = new_issue.user?.id || -1;
-  const isPrivate = new_repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(new_repository.private, config.redactPrivateRepoComments);
   const queueSettings = getEmbeddingQueueSettings(context.env);
 
   if (!isHumanAuthor) {

--- a/src/handlers/update-comments.ts
+++ b/src/handlers/update-comments.ts
@@ -3,6 +3,7 @@ import { addIssue } from "./add-issue";
 import { checkIfAnnotateFootNoteExists, removeAnnotateFootnotes } from "./annotate";
 import { ensurePullRequestIssue } from "./pull-request-review-utils";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 
 export async function updateComment(context: Context<"issue_comment.edited">) {
   const {
@@ -15,7 +16,7 @@ export async function updateComment(context: Context<"issue_comment.edited">) {
   const markdown = payload.comment.body;
   const authorId = payload.comment.user?.id || -1;
   const id = payload.comment.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
   const isPullRequestComment = !!payload.issue.pull_request;
   let issueId = payload.issue.node_id;
 

--- a/src/handlers/update-issue.ts
+++ b/src/handlers/update-issue.ts
@@ -1,6 +1,7 @@
 import { Context } from "../types/index";
 import { cleanContent } from "./issue-deduplication";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 
 export async function updateIssue(context: Context<"issues.edited">) {
   const {
@@ -10,7 +11,7 @@ export async function updateIssue(context: Context<"issues.edited">) {
     config,
   } = context;
   const id = payload.issue.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
   const authorType = payload.issue.user?.type;
   const isHumanAuthor = authorType === "User";
   let markdown = payload.issue.body && payload.issue.title ? payload.issue.body + " " + payload.issue.title : null;

--- a/src/handlers/update-pull-request-review.ts
+++ b/src/handlers/update-pull-request-review.ts
@@ -1,5 +1,6 @@
 import { Context } from "../types/index";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 import { removeAnnotateFootnotes } from "./annotate";
 import { buildPullRequestReviewMarkdown, ensurePullRequestIssue } from "./pull-request-review-utils";
 
@@ -49,7 +50,7 @@ export async function updatePullRequestReview(context: Context<"pull_request_rev
         id: review.node_id ?? `${review.id}`,
         author_id: review.user?.id ?? -1,
         payload,
-        isPrivate: payload.repository.private,
+        isPrivate: shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments),
         issue_id: issueId ?? pullRequest.node_id ?? null,
         docType: "pull_request_review",
       },

--- a/src/handlers/update-pull-request.ts
+++ b/src/handlers/update-pull-request.ts
@@ -1,6 +1,7 @@
 import { Context } from "../types/index";
 import { cleanContent } from "./issue-deduplication";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 import { buildPullRequestMarkdown } from "./pull-request-review-utils";
 
 export async function updatePullRequest(context: Context<"pull_request.edited">) {
@@ -16,7 +17,7 @@ export async function updatePullRequest(context: Context<"pull_request.edited">)
   const markdown = isHumanAuthor ? buildPullRequestMarkdown(pullRequest) : null;
   const authorId = pullRequest.user?.id || -1;
   const id = pullRequest.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
 
   if (!isHumanAuthor) {
     logger.debug("Pull request author is not human; storing PR without embeddings.", {

--- a/src/handlers/update-review-comments.ts
+++ b/src/handlers/update-review-comments.ts
@@ -1,5 +1,6 @@
 import { Context } from "../types/index";
 import { getEmbeddingQueueSettings } from "../utils/embedding-queue";
+import { shouldRedactPrivateRepoComments } from "../utils/privacy";
 import { removeAnnotateFootnotes } from "./annotate";
 import { buildReviewCommentMarkdown, ensurePullRequestIssue, fetchParentReviewComment, formatReviewThreadContext } from "./pull-request-review-utils";
 
@@ -14,7 +15,7 @@ export async function updateReviewComment(context: Context<"pull_request_review_
   const markdown = comment.body;
   const authorId = comment.user?.id || -1;
   const id = comment.node_id;
-  const isPrivate = payload.repository.private;
+  const isPrivate = shouldRedactPrivateRepoComments(payload.repository.private, config.redactPrivateRepoComments);
   const pullRequest = payload.pull_request;
 
   const isHumanAuthor = comment.user?.type === "User";

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -20,6 +20,10 @@ export const pluginSettingsSchema = T.Object(
       T.Number({ default: 0, description: "If set to a value greater than 0, the bot will always recommend contributors, regardless of the similarity score." })
     ),
     demoFlag: T.Boolean({ default: false, description: "When true, disables storing issues and comments in the database." }),
+    redactPrivateRepoComments: T.Boolean({
+      default: false,
+      description: "When true, redact markdown and payload content for private repositories before persisting.",
+    }),
   },
   { default: {} }
 );

--- a/src/utils/privacy.ts
+++ b/src/utils/privacy.ts
@@ -1,0 +1,3 @@
+export function shouldRedactPrivateRepoComments(repositoryIsPrivate: boolean, redactPrivateRepoComments?: boolean): boolean {
+  return repositoryIsPrivate && redactPrivateRepoComments === true;
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -579,6 +579,51 @@ describe("Plugin tests", () => {
     expect(comment.embedding).toBeDefined();
   });
 
+  it("When repository is private and redactPrivateRepoComments is false, it should preserve comment embeddings", async () => {
+    db.repo.update({
+      where: { id: { equals: 1 } },
+      data: { private: true },
+    });
+
+    const { context } = createContext(DEFAULT_BODY, 1, 1, 1, "privateCommentNoRedact", DEFAULT_ISSUE_ID);
+    context.config.redactPrivateRepoComments = false;
+
+    await runPlugin(context);
+
+    const comment = (await context.adapters.supabase.comment.getComment("privateCommentNoRedact")) as unknown as CommentMock;
+    expect(comment.embedding[0]).toBe(1);
+  });
+
+  it("When repository is private and redactPrivateRepoComments is true, it should redact comment embeddings", async () => {
+    db.repo.update({
+      where: { id: { equals: 1 } },
+      data: { private: true },
+    });
+
+    const { context } = createContext(DEFAULT_BODY, 1, 1, 1, "privateCommentRedacted", DEFAULT_ISSUE_ID);
+    context.config.redactPrivateRepoComments = true;
+
+    await runPlugin(context);
+
+    const comment = (await context.adapters.supabase.comment.getComment("privateCommentRedacted")) as unknown as CommentMock;
+    expect(comment.embedding[0]).toBe(0);
+  });
+
+  it("When repository is public and redactPrivateRepoComments is true, it should keep comment embeddings", async () => {
+    db.repo.update({
+      where: { id: { equals: 1 } },
+      data: { private: false },
+    });
+
+    const { context } = createContext(DEFAULT_BODY, 1, 1, 1, "publicCommentNoRedact", DEFAULT_ISSUE_ID);
+    context.config.redactPrivateRepoComments = true;
+
+    await runPlugin(context);
+
+    const comment = (await context.adapters.supabase.comment.getComment("publicCommentNoRedact")) as unknown as CommentMock;
+    expect(comment.embedding[0]).toBe(1);
+  });
+
   it("When a user uses annotate command with a specified comment and 'repo' scope and the comment doesn't have similarity above match threshold with any issue from the same repository, it shouldn't update comment body with footnotes", async () => {
     const [annotateIssue] = fetchSimilarIssues("annotate");
     const { context } = createContextIssues(annotateIssue.issue_body, "annotate", 9, annotateIssue.title);
@@ -702,6 +747,7 @@ describe("Plugin tests", () => {
         jobMatchingThreshold: 0.95,
         annotateThreshold: 0.65,
         demoFlag: false,
+        redactPrivateRepoComments: false,
       },
       command: null,
       adapters: {} as Context["adapters"],


### PR DESCRIPTION
## Summary
- add `redactPrivateRepoComments` plugin setting (default: `false`)
- centralize private-repo redaction decision and apply it across all document write paths (issues, comments, PRs, reviews, transfer/completion flows)
- add regression tests for private/public repo behavior with toggle on/off and document config usage in README

## Validation
- `bun run test`
- `bun run build`

Closes #23
