### PR TITLE
feat: add Nomic Embed v1.5 model for +10% retrieval accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a plugin for [UbiquityOS](https://github.com/ubiquity-os/ubiquity-os-ker
 - `SUPABASE_URL`: The URL for your Supabase instance.
 - `SUPABASE_KEY`: The key for your Supabase instance.
 - `VOYAGEAI_API_KEY`: The API key for Voyage.
+- `NOMIC_API_KEY`: The API key for Nomic (optional). When set, enables Nomic Embed v1.5 model (~10% higher accuracy than Voyage-4-large).
 - `EMBEDDINGS_QUEUE_ENABLED`: Enable deferred embedding processing via cron (default: true).
 - `EMBEDDINGS_QUEUE_BATCH_SIZE`: Max rows per cron batch (default: 50).
 - `EMBEDDINGS_QUEUE_DELAY_MS`: Delay between embeddings in milliseconds (default: 1000).
@@ -31,6 +32,7 @@ Cron GitHub App auth:
     dedupeWarningThreshold: 0.75
     annotateThreshold: 0.65
     jobMatchingThreshold: 0.75
+    embeddingModel: "nomic"  # Optional: "voyage" (default, 1024d) or "nomic" (768d, ~10% more accurate)
 ```
 
 ## Recommendations

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -8,8 +8,12 @@ import { Issue } from "./supabase/helpers/issues";
 import { SuperSupabase } from "./supabase/helpers/supabase";
 import { Embedding as VoyageEmbedding } from "./voyage/helpers/embedding";
 import { SuperVoyage } from "./voyage/helpers/voyage";
+import { Embedding as NomicEmbedding } from "./nomic/helpers/embedding";
+import { SuperNomic } from "./nomic/helpers/nomic";
 
-type AdapterSet = {
+export type EmbeddingModel = "voyage" | "nomic";
+
+export type AdapterSet = {
   supabase: {
     comment: Comment;
     issue: Issue;
@@ -18,6 +22,10 @@ type AdapterSet = {
   voyage: {
     embedding: VoyageEmbedding;
     super: SuperVoyage;
+  };
+  nomic: {
+    embedding: NomicEmbedding;
+    super: SuperNomic;
   };
   kv: CronDatabaseClient;
   llm: LlmAdapter;
@@ -34,7 +42,15 @@ export async function createAdapters(supabaseClient: SupabaseClient, voyage: Voy
       embedding: new VoyageEmbedding(voyage, context),
       super: new SuperVoyage(voyage, context),
     },
+    nomic: {
+      embedding: new NomicEmbedding(context),
+      super: new SuperNomic(context),
+    },
     kv: await createCronDatabase(),
     llm: new LlmAdapter(context),
   };
+}
+
+export function serializeEmbeddingForDatabase(embedding: number[] | null): string | null {
+  return embedding ? JSON.stringify(embedding) : null;
 }

--- a/src/adapters/nomic/helpers/embedding.ts
+++ b/src/adapters/nomic/helpers/embedding.ts
@@ -1,0 +1,75 @@
+import { SuperNomic } from "./nomic";
+import { Context } from "../../../types/context";
+
+// Nomic Embed v1.5 dimensions
+export const NOMIC_EMBEDDING_DIM = 768;
+export const NOMIC_MODEL = "nomic-embed-text-v1.5";
+
+export type NomicEmbeddingTaskType = "search_document" | "search_query" | "classification" | "clustering";
+
+export class Embedding extends SuperNomic {
+  protected context: Context;
+
+  constructor(context: Context) {
+    super(context);
+    this.context = context;
+  }
+
+  /**
+   * Creates a single embedding for the given text.
+   */
+  async createEmbedding(text: string | null, inputType: NomicEmbeddingTaskType = "search_document"): Promise<number[]> {
+    if (text === null) {
+      throw new Error("Text is null");
+    }
+    const embeddings = await this.createEmbeddings([text], inputType);
+    return embeddings[0] ?? [];
+  }
+
+  /**
+   * Creates multiple embeddings in a single API call.
+   */
+  async createEmbeddings(texts: string[], inputType: NomicEmbeddingTaskType = "search_document"): Promise<number[][]> {
+    if (texts.length === 0) {
+      return [];
+    }
+
+    const apiKey = this.context.env.NOMIC_API_KEY;
+    if (!apiKey) {
+      throw new Error("NOMIC_API_KEY is not set");
+    }
+
+    const response = await fetch("https://api.atlas.nomic.ai/v1/embedding/text", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        texts,
+        model: NOMIC_MODEL,
+        task_type: inputType,
+        truncation: true,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "Unknown error");
+      throw new Error(`Nomic API error ${response.status}: ${errorText}`);
+    }
+
+    const data = (await response.json()) as { embeddings: number[][] };
+
+    if (!data.embeddings || !Array.isArray(data.embeddings)) {
+      throw new Error("Invalid response from Nomic API: missing embeddings array");
+    }
+
+    // Validate dimensions
+    const dims = data.embeddings[0]?.length;
+    if (dims !== NOMIC_EMBEDDING_DIM) {
+      this.context.logger.warn(`Nomic embedding dimension mismatch. Expected ${NOMIC_EMBEDDING_DIM}, got ${dims}`);
+    }
+
+    return data.embeddings;
+  }
+}

--- a/src/adapters/nomic/helpers/nomic.ts
+++ b/src/adapters/nomic/helpers/nomic.ts
@@ -1,0 +1,9 @@
+import { Context } from "../../../types/context";
+
+export class SuperNomic {
+  protected context: Context;
+
+  constructor(context: Context) {
+    this.context = context;
+  }
+}

--- a/src/adapters/supabase/helpers/comment.ts
+++ b/src/adapters/supabase/helpers/comment.ts
@@ -5,6 +5,7 @@ import { COMMENT_DOCUMENT_TYPES, CommentDocumentType } from "../../../types/docu
 import { serializeEmbeddingForDatabase } from "../../../utils/database-embedding";
 import { cleanMarkdown, isTooShort, MIN_COMMENT_MARKDOWN_LENGTH } from "../../../utils/embedding-content";
 import { isCommandLikeContent } from "../../../utils/markdown-comments";
+import { PluginSettings } from "../../../types/plugin-input";
 
 export interface CommentType {
   id: string;
@@ -14,6 +15,7 @@ export interface CommentType {
   created_at: string;
   modified_at: string;
   embedding: number[] | null;
+  nomic_embedding: number[] | null;
   deleted_at?: string | null;
 }
 
@@ -42,6 +44,15 @@ interface FindSimilarCommentsParams {
   threshold: number;
 }
 
+function getEmbeddingModel(context: Context): "voyage" | "nomic" {
+  const config = context.config as PluginSettings | undefined;
+  return config?.embeddingModel ?? "voyage";
+}
+
+function isNomicAvailable(context: Context): boolean {
+  return !!context.env.NOMIC_API_KEY;
+}
+
 export class Comment extends SuperSupabase {
   constructor(supabase: SupabaseClient, context: Context) {
     super(supabase, context);
@@ -56,7 +67,8 @@ export class Comment extends SuperSupabase {
     const isShortComment = isTooShort(cleanedMarkdown, MIN_COMMENT_MARKDOWN_LENGTH);
     const shouldSkipEmbedding = isCommandComment || isShortComment;
     const embeddingSource = shouldSkipEmbedding ? null : cleanedMarkdown;
-    //First Check if the comment already exists
+
+    // First Check if the comment already exists
     const { data: existingData, error: existingError } = await this.supabase
       .from("documents")
       .select("*")
@@ -75,11 +87,28 @@ export class Comment extends SuperSupabase {
       });
       return;
     }
-    //Create the embedding for this comment
+
+    // Create embeddings for this comment
     let embedding: number[] | null = null;
+    let nomicEmbedding: number[] | null = null;
+
     if (!shouldDeferEmbedding && embeddingSource && !isPrivate) {
+      // Always create Voyage embedding
       embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
+
+      // Create Nomic embedding if API key is available
+      if (isNomicAvailable(this.context)) {
+        try {
+          nomicEmbedding = await this.context.adapters.nomic.embedding.createEmbedding(embeddingSource);
+        } catch (nomicError) {
+          this.context.logger.warn("Failed to create Nomic embedding for comment, continuing with Voyage only.", {
+            Error: nomicError instanceof Error ? nomicError : new Error(String(nomicError)),
+            commentId: commentData.id,
+          });
+        }
+      }
     }
+
     let finalMarkdown = shouldSkipEmbedding ? null : commentData.markdown;
     let finalPayload = commentData.payload;
 
@@ -87,17 +116,22 @@ export class Comment extends SuperSupabase {
       finalMarkdown = null;
       finalPayload = null;
     }
-    const { data, error } = await this.supabase.from("documents").insert([
-      {
-        id: commentData.id,
-        doc_type: docType,
-        parent_id: commentData.issue_id,
-        markdown: finalMarkdown,
-        author_id: commentData.author_id,
-        embedding: serializeEmbeddingForDatabase(embedding),
-        payload: finalPayload,
-      },
-    ]);
+
+    const insertData: Record<string, unknown> = {
+      id: commentData.id,
+      doc_type: docType,
+      parent_id: commentData.issue_id,
+      markdown: finalMarkdown,
+      author_id: commentData.author_id,
+      embedding: serializeEmbeddingForDatabase(embedding),
+      payload: finalPayload,
+    };
+
+    if (nomicEmbedding) {
+      insertData.nomic_embedding = serializeEmbeddingForDatabase(nomicEmbedding);
+    }
+
+    const { data, error } = await this.supabase.from("documents").insert([insertData]);
     if (error) {
       this.context.logger.error("Failed to create comment in database", {
         Error: error,
@@ -117,11 +151,28 @@ export class Comment extends SuperSupabase {
     const isShortComment = isTooShort(cleanedMarkdown, MIN_COMMENT_MARKDOWN_LENGTH);
     const shouldSkipEmbedding = isCommandComment || isShortComment;
     const embeddingSource = shouldSkipEmbedding ? null : cleanedMarkdown;
-    //Create the embedding for this comment
+
+    // Create embeddings for this comment
     let embedding: number[] | null = null;
+    let nomicEmbedding: number[] | null = null;
+
     if (!shouldDeferEmbedding && embeddingSource && !isPrivate) {
+      // Always create Voyage embedding
       embedding = Array.from(await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource));
+
+      // Create Nomic embedding if API key is available
+      if (isNomicAvailable(this.context)) {
+        try {
+          nomicEmbedding = Array.from(await this.context.adapters.nomic.embedding.createEmbedding(embeddingSource));
+        } catch (nomicError) {
+          this.context.logger.warn("Failed to create Nomic embedding during comment update, continuing with Voyage only.", {
+            Error: nomicError instanceof Error ? nomicError : new Error(String(nomicError)),
+            commentId: commentData.id,
+          });
+        }
+      }
     }
+
     let finalMarkdown = shouldSkipEmbedding ? null : commentData.markdown;
     let finalPayload = commentData.payload;
 
@@ -129,23 +180,26 @@ export class Comment extends SuperSupabase {
       finalMarkdown = null;
       finalPayload = null;
     }
+
     const comments = await this.getComment(commentData.id);
     if (comments && comments.length == 0) {
       this.context.logger.debug("Comment does not exist, creating a new one");
       await this.createComment({ ...commentData, markdown: finalMarkdown, payload: finalPayload, isPrivate }, { deferEmbedding: shouldDeferEmbedding });
     } else {
-      const { error } = await this.supabase
-        .from("documents")
-        .update({
-          doc_type: docType,
-          parent_id: commentData.issue_id,
-          markdown: finalMarkdown,
-          embedding: serializeEmbeddingForDatabase(embedding),
-          payload: finalPayload,
-          modified_at: new Date(),
-        })
-        .eq("id", commentData.id)
-        .in("doc_type", COMMENT_DOCUMENT_TYPES);
+      const updateData: Record<string, unknown> = {
+        doc_type: docType,
+        parent_id: commentData.issue_id,
+        markdown: finalMarkdown,
+        embedding: serializeEmbeddingForDatabase(embedding),
+        payload: finalPayload,
+        modified_at: new Date(),
+      };
+
+      if (nomicEmbedding) {
+        updateData.nomic_embedding = serializeEmbeddingForDatabase(nomicEmbedding);
+      }
+
+      const { error } = await this.supabase.from("documents").update(updateData).eq("id", commentData.id).in("doc_type", COMMENT_DOCUMENT_TYPES);
       if (error) {
         this.context.logger.error("Error updating comment", {
           Error: error,
@@ -209,7 +263,6 @@ export class Comment extends SuperSupabase {
   }
 
   async findSimilarComments({ markdown, currentId, threshold }: FindSimilarCommentsParams): Promise<CommentSimilaritySearchResult[] | null> {
-    // Create a new issue embedding
     try {
       const embeddingSource = cleanMarkdown(markdown);
       if (!embeddingSource) {
@@ -224,24 +277,46 @@ export class Comment extends SuperSupabase {
         });
         return null;
       }
-      const embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
-      const { data, error } = await this.supabase.rpc("find_similar_comments_annotate", {
-        query_embedding: embedding,
-        current_id: currentId,
-        threshold,
-        top_k: 5,
-      });
-      if (error) {
-        this.context.logger.error("Unable to find similar comments", {
-          Error: error,
-          markdown,
-          currentId,
+
+      const model = getEmbeddingModel(this.context);
+
+      if (model === "nomic" && isNomicAvailable(this.context)) {
+        const nomicEmbedding = await this.context.adapters.nomic.embedding.createEmbedding(embeddingSource);
+        const { data, error } = await this.supabase.rpc("find_similar_comments_nomic", {
+          query_embedding: nomicEmbedding,
           threshold,
-          query_embedding: embedding,
+          top_k: 5,
         });
-        return null;
+        if (error) {
+          this.context.logger.error("Unable to find similar comments (Nomic)", {
+            Error: error,
+            markdown,
+            currentId,
+            threshold,
+          });
+          return null;
+        }
+        return data;
+      } else {
+        const embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
+        const { data, error } = await this.supabase.rpc("find_similar_comments_annotate", {
+          query_embedding: embedding,
+          current_id: currentId,
+          threshold,
+          top_k: 5,
+        });
+        if (error) {
+          this.context.logger.error("Unable to find similar comments", {
+            Error: error,
+            markdown,
+            currentId,
+            threshold,
+            query_embedding: embedding,
+          });
+          return null;
+        }
+        return data;
       }
-      return data;
     } catch (error) {
       this.context.logger.error("Unable to find similar comments", {
         Error: error,

--- a/src/adapters/supabase/helpers/issues.ts
+++ b/src/adapters/supabase/helpers/issues.ts
@@ -4,6 +4,7 @@ import { Context } from "../../../types/context";
 import { IssueDocumentType, ISSUE_DOCUMENT_TYPES } from "../../../types/document";
 import { serializeEmbeddingForDatabase } from "../../../utils/database-embedding";
 import { cleanMarkdown, isTooShort, MIN_ISSUE_MARKDOWN_LENGTH } from "../../../utils/embedding-content";
+import { PluginSettings } from "../../../types/plugin-input";
 
 export interface IssueType {
   id: string;
@@ -13,6 +14,7 @@ export interface IssueType {
   created_at: string;
   modified_at: string;
   embedding: number[] | null;
+  nomic_embedding: number[] | null;
   deleted_at?: string | null;
 }
 
@@ -56,6 +58,15 @@ function resolveIssueDocType(payload: IssueData["payload"], explicitType?: Issue
   return "issue";
 }
 
+function getEmbeddingModel(context: Context): "voyage" | "nomic" {
+  const config = context.config as PluginSettings | undefined;
+  return config?.embeddingModel ?? "voyage";
+}
+
+function isNomicAvailable(context: Context): boolean {
+  return !!context.env.NOMIC_API_KEY;
+}
+
 export class Issue extends SuperSupabase {
   constructor(supabase: SupabaseClient, context: Context) {
     super(supabase, context);
@@ -68,7 +79,8 @@ export class Issue extends SuperSupabase {
     const cleanedMarkdown = cleanMarkdown(issueData.markdown);
     const isShortIssue = isTooShort(cleanedMarkdown, MIN_ISSUE_MARKDOWN_LENGTH);
     const embeddingSource = !isShortIssue ? cleanedMarkdown : null;
-    //First Check if the issue already exists
+
+    // First Check if the issue already exists
     const { data: existingData, error: existingError } = await this.supabase
       .from("documents")
       .select("*")
@@ -88,11 +100,27 @@ export class Issue extends SuperSupabase {
       return;
     }
 
-    //Create the embedding for this issue
+    // Create embeddings for this issue
     let embedding: number[] | null = null;
+    let nomicEmbedding: number[] | null = null;
+
     if (!shouldDeferEmbedding && embeddingSource && !isPrivate) {
+      // Always create Voyage embedding
       embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
+
+      // Create Nomic embedding if API key is available
+      if (isNomicAvailable(this.context)) {
+        try {
+          nomicEmbedding = await this.context.adapters.nomic.embedding.createEmbedding(embeddingSource);
+        } catch (nomicError) {
+          this.context.logger.warn("Failed to create Nomic embedding, continuing with Voyage only.", {
+            Error: nomicError instanceof Error ? nomicError : new Error(String(nomicError)),
+            issueId: issueData.id,
+          });
+        }
+      }
     }
+
     let finalMarkdown = isShortIssue ? null : issueData.markdown;
     let finalPayload = issueData.payload;
 
@@ -101,17 +129,22 @@ export class Issue extends SuperSupabase {
       finalPayload = null;
     }
 
-    const { data, error } = await this.supabase.from("documents").insert([
-      {
-        id: issueData.id,
-        doc_type: docType,
-        parent_id: null,
-        embedding: serializeEmbeddingForDatabase(embedding),
-        payload: finalPayload,
-        author_id: issueData.author_id,
-        markdown: finalMarkdown,
-      },
-    ]);
+    const insertData: Record<string, unknown> = {
+      id: issueData.id,
+      doc_type: docType,
+      parent_id: null,
+      embedding: serializeEmbeddingForDatabase(embedding),
+      payload: finalPayload,
+      author_id: issueData.author_id,
+      markdown: finalMarkdown,
+    };
+
+    // Only add nomic_embedding if it was successfully created
+    if (nomicEmbedding) {
+      insertData.nomic_embedding = serializeEmbeddingForDatabase(nomicEmbedding);
+    }
+
+    const { data, error } = await this.supabase.from("documents").insert([insertData]);
     if (error) {
       this.context.logger.error("Failed to create issue in database", {
         Error: error,
@@ -129,11 +162,28 @@ export class Issue extends SuperSupabase {
     const cleanedMarkdown = cleanMarkdown(issueData.markdown);
     const isShortIssue = isTooShort(cleanedMarkdown, MIN_ISSUE_MARKDOWN_LENGTH);
     const embeddingSource = !isShortIssue ? cleanedMarkdown : null;
-    //Create the embedding for this issue
+
+    // Create embeddings for this issue
     let embedding: number[] | null = null;
+    let nomicEmbedding: number[] | null = null;
+
     if (!shouldDeferEmbedding && embeddingSource && !isPrivate) {
+      // Always create Voyage embedding
       embedding = Array.from(await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource));
+
+      // Create Nomic embedding if API key is available
+      if (isNomicAvailable(this.context)) {
+        try {
+          nomicEmbedding = Array.from(await this.context.adapters.nomic.embedding.createEmbedding(embeddingSource));
+        } catch (nomicError) {
+          this.context.logger.warn("Failed to create Nomic embedding during update, continuing with Voyage only.", {
+            Error: nomicError instanceof Error ? nomicError : new Error(String(nomicError)),
+            issueId: issueData.id,
+          });
+        }
+      }
     }
+
     let finalMarkdown = isShortIssue ? null : issueData.markdown;
     let finalPayload = issueData.payload;
 
@@ -149,17 +199,19 @@ export class Issue extends SuperSupabase {
       return;
     }
 
-    const { error } = await this.supabase
-      .from("documents")
-      .update({
-        doc_type: docType,
-        markdown: finalMarkdown,
-        embedding: serializeEmbeddingForDatabase(embedding),
-        payload: finalPayload,
-        modified_at: new Date(),
-      })
-      .eq("id", issueData.id)
-      .in("doc_type", ISSUE_DOCUMENT_TYPES);
+    const updateData: Record<string, unknown> = {
+      doc_type: docType,
+      markdown: finalMarkdown,
+      embedding: serializeEmbeddingForDatabase(embedding),
+      payload: finalPayload,
+      modified_at: new Date(),
+    };
+
+    if (nomicEmbedding) {
+      updateData.nomic_embedding = serializeEmbeddingForDatabase(nomicEmbedding);
+    }
+
+    const { error } = await this.supabase.from("documents").update(updateData).eq("id", issueData.id).in("doc_type", ISSUE_DOCUMENT_TYPES);
 
     if (error) {
       this.context.logger.error("Error updating issue", {
@@ -214,7 +266,6 @@ export class Issue extends SuperSupabase {
   }
 
   async findSimilarIssues({ markdown, currentId, threshold }: FindSimilarIssuesParams): Promise<IssueSimilaritySearchResult[] | null> {
-    // Create a new issue embedding
     try {
       const embeddingSource = cleanMarkdown(markdown);
       if (!embeddingSource) {
@@ -229,24 +280,47 @@ export class Issue extends SuperSupabase {
         });
         return null;
       }
-      const embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
-      const { data, error } = await this.supabase.rpc("find_similar_issues_annotate", {
-        query_embedding: embedding,
-        current_id: currentId,
-        threshold,
-        top_k: 5,
-      });
-      if (error) {
-        this.context.logger.error("Unable to find similar issues", {
-          Error: error,
-          markdown,
-          currentId,
+
+      const model = getEmbeddingModel(this.context);
+
+      if (model === "nomic" && isNomicAvailable(this.context)) {
+        const nomicEmbedding = await this.context.adapters.nomic.embedding.createEmbedding(embeddingSource);
+        const { data, error } = await this.supabase.rpc("find_similar_issues_annotate_nomic", {
+          query_embedding: nomicEmbedding,
+          current_id: currentId,
           threshold,
-          query_embedding: embedding,
+          top_k: 5,
         });
-        return null;
+        if (error) {
+          this.context.logger.error("Unable to find similar issues (Nomic)", {
+            Error: error,
+            markdown,
+            currentId,
+            threshold,
+          });
+          return null;
+        }
+        return data;
+      } else {
+        const embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
+        const { data, error } = await this.supabase.rpc("find_similar_issues_annotate", {
+          query_embedding: embedding,
+          current_id: currentId,
+          threshold,
+          top_k: 5,
+        });
+        if (error) {
+          this.context.logger.error("Unable to find similar issues", {
+            Error: error,
+            markdown,
+            currentId,
+            threshold,
+            query_embedding: embedding,
+          });
+          return null;
+        }
+        return data;
       }
-      return data;
     } catch (error) {
       this.context.logger.error("Unable to find similar issues", {
         Error: error,
@@ -259,7 +333,6 @@ export class Issue extends SuperSupabase {
   }
 
   async findSimilarIssuesToMatch({ markdown, currentId, threshold, topK }: FindSimilarIssuesParams): Promise<IssueSimilaritySearchResult[] | null> {
-    // Create a new issue embedding
     try {
       const embeddingSource = cleanMarkdown(markdown);
       if (!embeddingSource) {
@@ -274,23 +347,45 @@ export class Issue extends SuperSupabase {
         });
         return null;
       }
-      const embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
-      const { data, error } = await this.supabase.rpc("find_similar_issues_to_match", {
-        current_id: currentId,
-        query_embedding: embedding,
-        threshold,
-        top_k: topK ?? 5,
-      });
-      if (error) {
-        this.context.logger.error("Error finding similar issues", {
-          Error: error,
-          markdown,
+
+      const model = getEmbeddingModel(this.context);
+
+      if (model === "nomic" && isNomicAvailable(this.context)) {
+        const nomicEmbedding = await this.context.adapters.nomic.embedding.createEmbedding(embeddingSource);
+        const { data, error } = await this.supabase.rpc("find_similar_issues_to_match_nomic", {
+          current_id: currentId,
+          query_embedding: nomicEmbedding,
           threshold,
-          query_embedding: embedding,
+          top_k: topK ?? 5,
         });
-        return null;
+        if (error) {
+          this.context.logger.error("Error finding similar issues (Nomic)", {
+            Error: error,
+            markdown,
+            threshold,
+          });
+          return null;
+        }
+        return data;
+      } else {
+        const embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
+        const { data, error } = await this.supabase.rpc("find_similar_issues_to_match", {
+          current_id: currentId,
+          query_embedding: embedding,
+          threshold,
+          top_k: topK ?? 5,
+        });
+        if (error) {
+          this.context.logger.error("Error finding similar issues", {
+            Error: error,
+            markdown,
+            threshold,
+            query_embedding: embedding,
+          });
+          return null;
+        }
+        return data;
       }
-      return data;
     } catch (error) {
       this.context.logger.error("Error finding similar issues", {
         Error: error,

--- a/src/cron/reprocess.ts
+++ b/src/cron/reprocess.ts
@@ -10,6 +10,8 @@ import { Issue } from "../adapters/supabase/helpers/issues";
 import { SuperSupabase } from "../adapters/supabase/helpers/supabase";
 import { Embedding as VoyageEmbedding } from "../adapters/voyage/helpers/embedding";
 import { SuperVoyage } from "../adapters/voyage/helpers/voyage";
+import { Embedding as NomicEmbedding } from "../adapters/nomic/helpers/embedding";
+import { SuperNomic } from "../adapters/nomic/helpers/nomic";
 import { issueDedupe } from "../handlers/issue-deduplication";
 import { issueMatchingWithComment } from "../handlers/issue-matching";
 import { updateIssue } from "../handlers/update-issue";
@@ -108,6 +110,10 @@ export function createReprocessAdapters(context: Context, clients: ReprocessClie
     voyage: {
       embedding: new VoyageEmbedding(clients.voyage, context),
       super: new SuperVoyage(clients.voyage, context),
+    },
+    nomic: {
+      embedding: new NomicEmbedding(context),
+      super: new SuperNomic(context),
     },
     kv,
     llm: new LlmAdapter(context),

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -21,6 +21,7 @@ export type Database = {
           id: string;
           markdown: string | null;
           modified_at: string;
+          nomic_embedding: string | null;
           parent_id: string | null;
           payload: Json | null;
         };
@@ -36,6 +37,7 @@ export type Database = {
           id: string;
           markdown?: string | null;
           modified_at?: string;
+          nomic_embedding?: string | null;
           parent_id?: string | null;
           payload?: Json | null;
         };
@@ -51,6 +53,7 @@ export type Database = {
           id?: string;
           markdown?: string | null;
           modified_at?: string;
+          nomic_embedding?: string | null;
           parent_id?: string | null;
           payload?: Json | null;
         };

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -11,6 +11,7 @@ export const envSchema = T.Object({
   SUPABASE_URL: T.String(),
   SUPABASE_KEY: T.String(),
   VOYAGEAI_API_KEY: T.String(),
+  NOMIC_API_KEY: T.Optional(T.String()),
   DENO_KV_URL: T.Optional(T.String()),
   LOG_LEVEL: T.Optional(T.String()),
   KERNEL_PUBLIC_KEY: T.Optional(T.String()),

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -20,6 +20,12 @@ export const pluginSettingsSchema = T.Object(
       T.Number({ default: 0, description: "If set to a value greater than 0, the bot will always recommend contributors, regardless of the similarity score." })
     ),
     demoFlag: T.Boolean({ default: false, description: "When true, disables storing issues and comments in the database." }),
+    embeddingModel: T.Optional(
+      T.Union([T.Literal("voyage"), T.Literal("nomic")], {
+        default: "voyage",
+        description: "Which embedding model to use: 'voyage' (Voyage-4-large, 1024d) or 'nomic' (Nomic Embed v1.5, 768d, ~10% more accurate).",
+      })
+    ),
   },
   { default: {} }
 );

--- a/supabase/migrations/20260331000000_nomic_embedding.sql
+++ b/supabase/migrations/20260331000000_nomic_embedding.sql
@@ -1,0 +1,116 @@
+-- Add Nomic Embed v1.5 column (768 dimensions)
+-- Nomic Embed v1.5 offers ~10% improved retrieval accuracy vs Voyage-4-large
+-- See: https://github.com/ubiquity-os-marketplace/text-vector-embeddings/issues/111
+
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS nomic_embedding vector(768);
+
+-- Index for Nomic embedding similarity search
+CREATE INDEX IF NOT EXISTS documents_nomic_embedding_ivfflat
+  ON public.documents USING ivfflat (nomic_embedding vector_cosine_ops)
+  WITH (lists = '10');
+
+-- Update embedding_model to include 'nomic' as valid value
+-- The CHECK constraint is on embedding_status so no change needed there.
+-- The embedding_model column is free-form text so no schema change needed.
+
+-- Add comment for documentation
+COMMENT ON COLUMN documents.nomic_embedding IS 'Nomic Embed v1.5 embeddings (768d). Used when embeddingModel setting is "nomic". Provides ~10% higher retrieval accuracy than Voyage-4-large.';
+
+-- Nomic-specific similarity search functions (768d vectors)
+-- These mirror the Voyage functions but use the nomic_embedding column
+
+CREATE OR REPLACE FUNCTION find_similar_issues_nomic(current_id VARCHAR, query_embedding vector(768), threshold float8, top_k INT)
+RETURNS TABLE(issue_id VARCHAR, similarity float8) AS $$
+DECLARE
+    current_repo TEXT;
+    current_org TEXT;
+BEGIN
+    SELECT
+        payload->'repository'->>'name'::text,
+        payload->'repository'->'owner'->>'login'::text
+    INTO current_repo, current_org
+    FROM documents
+    WHERE id = current_id
+      AND doc_type = 'issue';
+
+    RETURN QUERY
+    SELECT sub.issue_id,
+           sub.similarity
+    FROM (
+        SELECT id AS issue_id,
+               ((0.8 * (1 - cosine_distance(query_embedding, nomic_embedding))) + 0.8 * (1 / (1 + l2_distance(query_embedding, nomic_embedding)))) as similarity
+        FROM documents
+        WHERE id <> current_id
+            AND doc_type = 'issue'
+            AND deleted_at IS NULL
+            AND nomic_embedding IS NOT NULL
+            AND COALESCE(payload->'repository'->>'name', '') = COALESCE(current_repo, '')
+            AND COALESCE(payload->'repository'->'owner'->>'login', '') = COALESCE(current_org, '')
+    ) sub
+    WHERE sub.similarity > threshold
+    ORDER BY sub.similarity DESC
+    LIMIT top_k;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION find_similar_comments_nomic(query_embedding vector(768), threshold float8, top_k INT)
+RETURNS TABLE(comment_id VARCHAR, similarity float8) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT sub.comment_id,
+           sub.similarity
+    FROM (
+        SELECT id AS comment_id,
+               ((0.8 * (1 - cosine_distance(query_embedding, nomic_embedding))) + 0.8 * (1 / (1 + l2_distance(query_embedding, nomic_embedding)))) as similarity
+        FROM documents
+        WHERE deleted_at IS NULL
+            AND nomic_embedding IS NOT NULL
+            AND doc_type IN ('issue_comment', 'review_comment', 'pull_request_review')
+    ) sub
+    WHERE sub.similarity > threshold
+    ORDER BY sub.similarity DESC
+    LIMIT top_k;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION find_similar_issues_annotate_nomic(current_id VARCHAR, query_embedding vector(768), threshold float8, top_k INT)
+RETURNS TABLE(issue_id VARCHAR, similarity float8) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT sub.issue_id,
+           sub.similarity
+    FROM (
+        SELECT id AS issue_id,
+               ((0.7 * (1 - cosine_distance(query_embedding, nomic_embedding))) + 0.3 * (1 / (1 + l2_distance(query_embedding, nomic_embedding)))) as similarity
+        FROM documents
+        WHERE id <> current_id
+            AND doc_type = 'issue'
+            AND deleted_at IS NULL
+            AND nomic_embedding IS NOT NULL
+    ) sub
+    WHERE sub.similarity > threshold
+    ORDER BY sub.similarity DESC
+    LIMIT top_k;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION find_similar_issues_to_match_nomic(current_id VARCHAR, query_embedding vector(768), threshold float8, top_k INT)
+RETURNS TABLE(issue_id VARCHAR, similarity float8) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT sub.issue_id,
+           sub.similarity
+    FROM (
+        SELECT id AS issue_id,
+               ((0.8 * (1 - cosine_distance(query_embedding, nomic_embedding))) + 0.2 * (1 / (1 + l2_distance(query_embedding, nomic_embedding)))) as similarity
+        FROM documents
+        WHERE id <> current_id
+            AND doc_type = 'issue'
+            AND deleted_at IS NULL
+            AND nomic_embedding IS NOT NULL
+    ) sub
+    WHERE sub.similarity > threshold
+    ORDER BY sub.similarity DESC
+    LIMIT top_k;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Implements Nomic Embed v1.5 model integration for improved retrieval accuracy as described in [issue #111](https://github.com/ubiquity-os-marketplace/text-vector-embeddings/issues/111).

### Changes

**New Files:**
- `src/adapters/nomic/helpers/nomic.ts` - Base Nomic adapter class
- `src/adapters/nomic/helpers/embedding.ts` - Nomic Embed v1.5 API client (768d, 8192 tokens)
- `supabase/migrations/20260331000000_nomic_embedding.sql` - DB migration for `nomic_embedding` column + IVFFlat index + Nomic-specific RPC functions

**Modified Files:**
- `src/types/env.ts` - Added `NOMIC_API_KEY` (optional)
- `src/types/plugin-input.ts` - Added `embeddingModel` setting ("voyage" | "nomic")
- `src/adapters/index.ts` - Added Nomic to `AdapterSet`; exported `EmbeddingModel` type
- `src/adapters/supabase/helpers/issues.ts` - Creates both Voyage + Nomic embeddings; similarity search uses configured model
- `src/adapters/supabase/helpers/comment.ts` - Same dual-embedding pattern
- `src/cron/reprocess.ts` - Added Nomic adapter to reprocess context
- `src/types/database.ts` - Added `nomic_embedding` column to `documents` table type
- `README.md` - Documented `NOMIC_API_KEY` env var and `embeddingModel` setting

### Architecture

- **Dual-model storage**: Both `embedding` (Voyage, 1024d) and `nomic_embedding` (Nomic, 768d) are stored per document when Nomic API key is available
- **Configurable similarity search**: The `embeddingModel` setting controls which model's space is used for vector search
- **Backward compatible**: Voyage remains the default; Nomic is an optional enhancement
- **Graceful fallback**: If Nomic API call fails, Voyage embedding is still used

### Devpool

Closes [devpool-directory#5064](https://github.com/devpool-directory/devpool-directory/issues/5064) ($900) - Nomic Embeddings Model for +10% Accuracy
