### PR TITLE
fix: normalize GitHub issue URLs in dedupe footnotes

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -4,6 +4,7 @@ import { processSimilarIssues, IssueGraphqlResponse, findMostSimilarSentence } f
 import { CommentSimilaritySearchResult } from "../adapters/supabase/helpers/comment";
 import { stripHtmlComments } from "../utils/markdown-comments";
 import { appendFootnoteRefsToFirstLine, insertFootnoteRefNearSentence } from "../utils/footnote-placement";
+import { normalizeGitHubCommentUrl, normalizeGitHubIssueUrl } from "../utils/github-url";
 
 interface CommentGraphqlResponse {
   node: {
@@ -155,7 +156,7 @@ async function handleSimilarIssuesAndComments(
   issueList.forEach((issue, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
     const footnoteRef = `[^0${footnoteIndex}^]`;
-    const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
+    const modifiedUrl = normalizeGitHubIssueUrl(issue.node.url);
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
     if (!sentence.trim()) {
@@ -185,7 +186,7 @@ async function handleSimilarIssuesAndComments(
   commentList.forEach((comment, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
     const footnoteRef = `[^0${footnoteIndex}^]`;
-    const modifiedUrl = comment.node.url.replace("https://github.com", "https://www.github.com");
+    const modifiedUrl = normalizeGitHubCommentUrl(comment.node.url);
     const { sentence } = comment.mostSimilarSentence;
     // Insert footnote reference in the body
     if (!sentence.trim()) {

--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -5,6 +5,7 @@ import { IssueSimilaritySearchResult } from "../adapters/supabase/helpers/issues
 import { Context } from "../types/index";
 import { appendPluginUpdateComment, normalizeWhitespace, stripHtmlComments, stripPluginUpdateComments } from "../utils/markdown-comments";
 import { appendFootnoteRefsToFirstLine, insertFootnoteRefNearSentence } from "../utils/footnote-placement";
+import { normalizeGitHubIssueUrl } from "../utils/github-url";
 import { stripDuplicateFootnotes } from "../utils/footnotes";
 import { findEditDistance } from "../utils/string-similarity";
 
@@ -205,7 +206,7 @@ async function handleSimilarIssuesComment(
   relevantIssues.forEach((issue, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
     const footnoteRef = `[^0${footnoteIndex}^]`;
-    const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
+    const modifiedUrl = normalizeGitHubIssueUrl(issue.node.url);
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
     if (!sentence.trim()) {
@@ -271,7 +272,7 @@ async function handleMatchIssuesComment(
   relevantIssues.sort((a, b) => parseFloat(b.similarity) - parseFloat(a.similarity));
   // Append the similar issues to the resultBuilder
   relevantIssues.forEach((issue) => {
-    const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
+    const modifiedUrl = normalizeGitHubIssueUrl(issue.node.url);
     resultBuilder += `> - [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n`;
   });
   // Insert the resultBuilder into the issue body

--- a/src/utils/github-url.ts
+++ b/src/utils/github-url.ts
@@ -1,0 +1,7 @@
+export function normalizeGitHubIssueUrl(url: string): string {
+  return url.split("#")[0].replace("https://github.com", "https://www.github.com");
+}
+
+export function normalizeGitHubCommentUrl(url: string): string {
+  return url.replace("https://github.com", "https://www.github.com");
+}

--- a/tests/__mocks__/handlers.ts
+++ b/tests/__mocks__/handlers.ts
@@ -49,6 +49,8 @@ export const handlers = [
     }
     return HttpResponse.json(item);
   }),
+  // get GitHub issue web pages used by markdown-link enrichment
+  http.get("https://www.github.com/:owner/:repo/issues/:issue_number", () => HttpResponse.json({})),
   // create comment
   http.post("https://api.github.com/repos/:owner/:repo/issues/:issue_number/comments", async ({ params: { issue_number: issueNumber }, request }) => {
     const { body } = await getValue(request.body);

--- a/tests/github-url.test.ts
+++ b/tests/github-url.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeGitHubCommentUrl, normalizeGitHubIssueUrl } from "../src/utils/github-url";
+
+describe("normalizeGitHubIssueUrl", () => {
+  it("strips hash fragments before converting to the www.github.com domain", () => {
+    expect(normalizeGitHubIssueUrl("https://github.com/acme/project/issues/12#issuecomment-12345")).toBe("https://www.github.com/acme/project/issues/12");
+  });
+
+  it("preserves plain issue URLs while normalizing the domain", () => {
+    expect(normalizeGitHubIssueUrl("https://github.com/acme/project/issues/12")).toBe("https://www.github.com/acme/project/issues/12");
+  });
+});
+
+describe("normalizeGitHubCommentUrl", () => {
+  it("preserves hash fragments for comment links while normalizing the domain", () => {
+    expect(normalizeGitHubCommentUrl("https://github.com/acme/project/issues/12#issuecomment-12345")).toBe(
+      "https://www.github.com/acme/project/issues/12#issuecomment-12345"
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- Normalize GitHub issue URLs before generating dedupe footnotes\n- Add a test fixture for the www.github.com issue-page URL used by the enrichment tests\n\n## Testing\n- bun test\n\n## Notes\n- Closes #93