### PR TITLE
fix: address dedupe review adjustments

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -144,7 +144,7 @@ async function handleSimilarIssuesAndComments(
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
+  const footnoteRegex = /\[\^(?:deduplication-)?(\d+)\^\]/g;
   const existingFootnotes = commentBody.match(footnoteRegex) || [];
   let highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn.match(/\d+/)?.[0] ?? "0"))) : 0;
   let updatedBody = commentBody;
@@ -154,7 +154,7 @@ async function handleSimilarIssuesAndComments(
   issueList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   issueList.forEach((issue, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = `[^deduplication-${footnoteIndex}^]`;
     const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -184,7 +184,7 @@ async function handleSimilarIssuesAndComments(
   commentList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   commentList.forEach((comment, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = `[^deduplication-${footnoteIndex}^]`;
     const modifiedUrl = comment.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = comment.mostSimilarSentence;
     // Insert footnote reference in the body

--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -194,7 +194,7 @@ async function handleSimilarIssuesComment(
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
+  const footnoteRegex = /\[\^(?:deduplication-)?(\d+)\^\]/g;
   const existingFootnotes = issueBody.match(footnoteRegex) || [];
   const highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn.match(/\d+/)?.[0] ?? "0"))) : 0;
   let updatedBody = issueBody;
@@ -204,7 +204,7 @@ async function handleSimilarIssuesComment(
   relevantIssues.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   relevantIssues.forEach((issue, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = `[^deduplication-${footnoteIndex}^]`;
     const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -262,7 +262,7 @@ async function handleMatchIssuesComment(
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
+  const footnoteRegex = /\[\^(?:deduplication-)?(\d+)\^\]/g;
   const existingFootnotes = issueBody.match(footnoteRegex) || [];
   // Find the index with respect to the issue body string where the footnotes start if they exist
   const footnoteIndex = existingFootnotes[0] ? issueBody.indexOf(existingFootnotes[0]) : issueBody.length;

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -17,7 +17,10 @@ export const pluginSettingsSchema = T.Object(
     }),
     jobMatchingThreshold: T.Number({ default: 0.75, description: "The minimum similarity score when considering users to be suitable for a job." }),
     alwaysRecommend: T.Optional(
-      T.Number({ default: 0, description: "If set to a value greater than 0, the bot will always recommend contributors, regardless of the similarity score." })
+      T.Number({
+        default: 0,
+        description: "If set to a value greater than 0, this amount of contributors will always be recommended regardless of the similarity score.",
+      })
     ),
     demoFlag: T.Boolean({ default: false, description: "When true, disables storing issues and comments in the database." }),
   },

--- a/src/utils/footnotes.ts
+++ b/src/utils/footnotes.ts
@@ -1,4 +1,4 @@
-const FOOTNOTE_DEF_REGEX = /\[\^(\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
+const FOOTNOTE_DEF_REGEX = /\[\^((?:deduplication-)?\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
 
 export function removeCautionMessages(content: string): string {
   const cautionRegex = />[!CAUTION]\n> This issue may be a duplicate of the following issues:\n((> - \[[^\]]+\]\([^)]+\)\n)+)/g;

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
 
-export const urlSchema = v.pipe(v.string(), v.url(), v.regex(/https:\/\/github\.com\/[^/]+\/[^/]+\/(issues|pull)\/\d+$/));
+export const urlSchema = v.pipe(v.string(), v.url(), v.regex(/^https:\/\/(?:www\.)?github\.com\/[^/]+\/[^/]+\/(issues|pull)\/\d+\/?$/));
 
 export const querySchema = v.object({
   issueUrls: v.union([v.array(urlSchema), urlSchema]),

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -182,8 +182,8 @@ describe("Plugin tests", () => {
       context2.octokit.rest.issues.update = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
         // Find the most similar sentence (first sentence in this case)
         const updatedBody =
-          warningThresholdIssue2.issue_body.replace(STRINGS.SIMILAR_ISSUE_TITLE, `${STRINGS.SIMILAR_ISSUE_TITLE}[^01^]`) +
-          `\n\n[^01^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
+          warningThresholdIssue2.issue_body.replace(STRINGS.SIMILAR_ISSUE_TITLE, `${STRINGS.SIMILAR_ISSUE_TITLE}[^deduplication-1^]`) +
+          `\n\n[^deduplication-1^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
 
         db.issue.update({
           where: {
@@ -199,7 +199,7 @@ describe("Plugin tests", () => {
 
       const issue = db.issue.findFirst({ where: { node_id: { equals: "warning2" } } }) as unknown as Context["payload"]["issue"];
       expect(issue.state).toBe("open");
-      expect(issue.body).toContain(`[^01^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+      expect(issue.body).toContain(`[^deduplication-1^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
     }
   );
 
@@ -459,11 +459,11 @@ describe("Plugin tests", () => {
     expect(issue.state).toBe("open");
     // Verify the footnote is added after the line containing the markdown link
     expect(issue.body).toContain(
-      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_ [^01^]"
+      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_ [^deduplication-1^]"
     );
     // Verify the markdown link is not broken
     expect(issue.body).not.toContain(
-      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_[^01^]"
+      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_[^deduplication-1^]"
     );
   });
 
@@ -509,8 +509,8 @@ describe("Plugin tests", () => {
     context2.octokit.rest.issues.updateComment = mock(async (params: { owner: string; repo: string; comment_id: number; body: string }) => {
       // Find the most similar sentence (first sentence in this case)
       const updatedBody =
-        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^01^]`) +
-        `\n\n[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
+        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^deduplication-1^]`) +
+        `\n\n[^deduplication-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
 
       db.issueComments.update({
         where: {
@@ -525,7 +525,7 @@ describe("Plugin tests", () => {
     await runPlugin(context2);
 
     const updatedComment = db.issueComments.findFirst({ where: { id: { equals: 1 } } }) as unknown as Context<"issue_comment.created">["payload"]["comment"];
-    expect(updatedComment.body).toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    expect(updatedComment.body).toContain(`[^deduplication-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
   it("When demoFlag is true, it should skip storing issues in the database", async () => {
@@ -621,8 +621,8 @@ describe("Plugin tests", () => {
     context2.octokit.rest.issues.updateComment = mock(async (params: { owner: string; repo: string; comment_id: number; body: string }) => {
       // Find the most similar sentence (first sentence in this case)
       const updatedBody =
-        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^01^]`) +
-        `\n\n[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
+        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^deduplication-1^]`) +
+        `\n\n[^deduplication-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
 
       db.issueComments.update({
         where: {
@@ -637,7 +637,7 @@ describe("Plugin tests", () => {
     await runPlugin(context2);
 
     const updatedComment = db.issueComments.findFirst({ where: { id: { equals: 1 } } }) as unknown as Context<"issue_comment.created">["payload"]["comment"];
-    expect(updatedComment.body).not.toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    expect(updatedComment.body).not.toContain(`[^deduplication-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
   function createContext(


### PR DESCRIPTION
## Summary
- switch deduplication/annotation footnote IDs from zero-prefixed numeric refs to `deduplication-*` refs while preserving cleanup of old numeric refs
- make recommendation config wording more precise for `alwaysRecommend`
- accept friendlier GitHub issue/PR URLs with `www.` and trailing slash
- update regression expectations for the new footnote prefix

## Validation
- `bun install`
- `bun run build`
- `bun test tests/main.test.ts`
- `git diff --check`

Resolves #92
/claim #92