### PR TITLE
Use GitHub formal duplicate marking

### DIFF
--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -10,6 +10,7 @@ import { findEditDistance } from "../utils/string-similarity";
 
 export interface IssueGraphqlResponse {
   node: {
+    id: string;
     title: string;
     number: number;
     url: string;
@@ -74,23 +75,19 @@ export async function issueDedupe(context: Context<"issues.opened" | "issues.edi
     const matchIssues = processedIssues.filter((issue) => parseFloat(issue.similarity) / 100 >= context.config.dedupeMatchThreshold);
     if (matchIssues.length > 0) {
       logger.info(`Similar issue which matches more than ${context.config.dedupeMatchThreshold} already exists`, { matchIssues });
-      //To the issue body, add a footnote with the link to the similar issue
-      const updatedBody = await handleMatchIssuesComment(context, payload, cleanedIssueBody, processedIssues);
-      const outputBody = updatedBody || cleanedIssueBody;
-      const nextBody = updateComment ? appendPluginUpdateComment(outputBody, updateComment) : outputBody;
-      const isBodyUnchanged = normalizeWhitespace(originalIssue.body ?? "") === normalizeWhitespace(nextBody);
-      const shouldClose = originalIssue.state !== "closed" || originalIssue.state_reason !== "not_planned";
-      if (isBodyUnchanged && !shouldClose) {
-        logger.info("Issue body unchanged after dedupe match update", { issueNumber: originalIssue.number });
+      const canonicalIssue = [...matchIssues].sort((a, b) => parseFloat(b.similarity) - parseFloat(a.similarity))[0];
+      if (originalIssue.state === "closed") {
+        logger.info("Issue already closed; skipping formal duplicate marking", {
+          issueNumber: originalIssue.number,
+          duplicateOf: canonicalIssue.node.number,
+        });
         return;
       }
-      await octokit.rest.issues.update({
-        owner: payload.repository.owner.login,
-        repo: payload.repository.name,
-        issue_number: originalIssue.number,
-        body: nextBody,
-        state: "closed",
-        state_reason: "not_planned",
+
+      await markIssueAsDuplicate(context, originalIssue.node_id, canonicalIssue.node.id);
+      logger.info("Marked issue as a formal duplicate", {
+        issueNumber: originalIssue.number,
+        duplicateOf: canonicalIssue.node.number,
       });
       return;
     }
@@ -251,34 +248,6 @@ async function handleSimilarIssuesComment(
   });
 }
 
-//When similarity is greater than match threshold, Add Caution mentioning the issues to which its is very much similar
-async function handleMatchIssuesComment(
-  context: Context,
-  payload: Context<"issues.opened" | "issues.edited">["payload"],
-  issueBody: string,
-  relevantIssues: IssueGraphqlResponse[]
-): Promise<string | undefined> {
-  if (!issueBody) {
-    return;
-  }
-  // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
-  const existingFootnotes = issueBody.match(footnoteRegex) || [];
-  // Find the index with respect to the issue body string where the footnotes start if they exist
-  const footnoteIndex = existingFootnotes[0] ? issueBody.indexOf(existingFootnotes[0]) : issueBody.length;
-  let resultBuilder = "\n\n>[!CAUTION]\n> This issue may be a duplicate of the following issues:\n";
-  // Sort relevant issues by similarity in descending order
-  relevantIssues.sort((a, b) => parseFloat(b.similarity) - parseFloat(a.similarity));
-  // Append the similar issues to the resultBuilder
-  relevantIssues.forEach((issue) => {
-    const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
-    resultBuilder += `> - [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n`;
-  });
-  // Insert the resultBuilder into the issue body
-  // Update the issue with the modified body
-  return issueBody.slice(0, footnoteIndex) + resultBuilder + issueBody.slice(footnoteIndex);
-}
-
 // Process similar issues and return the list of similar issues with their similarity scores
 export async function processSimilarIssues(similarIssues: IssueSimilaritySearchResult[], context: Context, issueBody: string): Promise<IssueGraphqlResponse[]> {
   const processedIssues = await Promise.all(
@@ -290,6 +259,7 @@ export async function processSimilarIssues(similarIssues: IssueSimilaritySearchR
             query ($issueNodeId: ID!) {
               node(id: $issueNodeId) {
                 ... on Issue {
+                  id
                   title
                   url
                   number
@@ -317,6 +287,28 @@ export async function processSimilarIssues(similarIssues: IssueSimilaritySearchR
     })
   );
   return processedIssues.filter((issue): issue is IssueGraphqlResponse => issue !== null);
+}
+
+async function markIssueAsDuplicate(context: Context<"issues.opened" | "issues.edited">, duplicateId: string, canonicalId: string) {
+  await context.octokit.graphql(
+    /* GraphQL */
+    `
+      mutation MarkIssueAsDuplicate($duplicateId: ID!, $canonicalId: ID!) {
+        markIssueAsDuplicate(input: { duplicateId: $duplicateId, canonicalId: $canonicalId }) {
+          duplicate {
+            id
+          }
+          canonical {
+            id
+          }
+        }
+      }
+    `,
+    {
+      duplicateId,
+      canonicalId,
+    }
+  );
 }
 
 /**

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -203,7 +203,7 @@ describe("Plugin tests", () => {
     }
   );
 
-  it("When an issue is created with similarity above match threshold, it should close the issue and add a caution alert", async () => {
+  it("When an issue is created with similarity above match threshold, it should mark the issue as a formal duplicate", async () => {
     const [matchThresholdIssue1, matchThresholdIssue2] = fetchSimilarIssues("match_threshold_95");
     const { context } = createContextIssues(matchThresholdIssue1.issue_body, "match1", 3, matchThresholdIssue1.title);
     context.eventName = ISSUES_EDITED_EVENT_NAME;
@@ -229,21 +229,40 @@ describe("Plugin tests", () => {
     context2.adapters.supabase.issue.findSimilarIssues = mock().mockResolvedValue([
       { issue_id: "match1", similarity: 0.96 },
     ] as unknown as IssueSimilaritySearchResult[]);
-    context2.octokit.graphql = mock().mockResolvedValue({
-      node: {
-        title: STRINGS.SIMILAR_ISSUE,
-        url: STRINGS.ISSUE_URL,
-        number: 3,
-        lastEditedAt: "2020-01-12T17:52:02Z",
-        body: matchThresholdIssue1.issue_body,
-        repository: {
-          name: STRINGS.TEST_REPO,
-          owner: {
-            login: STRINGS.USER_1,
+    let markDuplicateVariables: { duplicateId?: string; canonicalId?: string } | undefined;
+    const graphqlMock = mock(async (query: string, variables?: { duplicateId?: string; canonicalId?: string }) => {
+      if (query.includes("markIssueAsDuplicate")) {
+        markDuplicateVariables = variables;
+        return {
+          markIssueAsDuplicate: {
+            duplicate: {
+              id: "match2",
+            },
+            canonical: {
+              id: "match1",
+            },
+          },
+        };
+      }
+
+      return {
+        node: {
+          id: "match1",
+          title: STRINGS.SIMILAR_ISSUE,
+          url: STRINGS.ISSUE_URL,
+          number: 3,
+          lastEditedAt: "2020-01-12T17:52:02Z",
+          body: matchThresholdIssue1.issue_body,
+          repository: {
+            name: STRINGS.TEST_REPO,
+            owner: {
+              login: STRINGS.USER_1,
+            },
           },
         },
-      },
-    }) as unknown as typeof context2.octokit.graphql;
+      };
+    });
+    context2.octokit.graphql = graphqlMock as unknown as typeof context2.octokit.graphql;
 
     context2.adapters.supabase.issue.createIssue = mock(async () => {
       createIssue(
@@ -259,29 +278,18 @@ describe("Plugin tests", () => {
       );
     });
 
-    context2.octokit.rest.issues.update = mock(
-      async (params: { owner: string; repo: string; issue_number: number; body?: string; state?: string; state_reason?: string }) => {
-        const updatedBody = `${matchThresholdIssue2.issue_body}\n\n>[!CAUTION]\n> This issue may be a duplicate of the following issues:\n> - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n`;
-        db.issue.update({
-          where: {
-            number: { equals: params.issue_number },
-          },
-          data: {
-            ...(params.body && { body: updatedBody }),
-            ...(params.state && { state: params.state }),
-            ...(params.state_reason && { state_reason: params.state_reason }),
-          },
-        });
-      }
-    ) as unknown as typeof octokit.rest.issues.update;
+    context2.octokit.rest.issues.update = mock(async () => undefined) as unknown as typeof octokit.rest.issues.update;
 
     await runPlugin(context2);
     const issue = db.issue.findFirst({ where: { number: { equals: 4 } } }) as unknown as Context["payload"]["issue"];
-    expect(issue.state).toBe("closed");
-    expect(issue.state_reason).toBe("not_planned");
-    expect(issue.body).toContain(">[!CAUTION]");
-    expect(issue.body).toContain("This issue may be a duplicate of the following issues:");
-    expect(issue.body).toContain(`- [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    expect(markDuplicateVariables).toEqual({
+      duplicateId: "match2",
+      canonicalId: "match1",
+    });
+    expect(graphqlMock).toHaveBeenCalledTimes(2);
+    expect(context2.octokit.rest.issues.update).not.toHaveBeenCalled();
+    expect(issue.body).not.toContain(">[!CAUTION]");
+    expect(issue.body).not.toContain("This issue may be a duplicate of the following issues:");
   });
 
   it("When issue matching is triggered, it should suggest contributors based on similarity", async () => {


### PR DESCRIPTION
## Summary
- query similar issue node IDs during dedupe processing
- replace match-threshold REST close/body CAUTION updates with GitHub's formal duplicate marker
- update the match-threshold test to assert the duplicate mutation instead of body mutation

Closes #74

## Testing
Not run (not requested).