### PR TITLE
Deduplicate matchmaking recommendation comments

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -31,14 +31,73 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+type IssueTarget = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
+}
+
+function isMatchmakingComment(commentStart: string, comment: IssueCommentSummary) {
+  return Boolean(comment.body && comment.body.includes(">[!NOTE]" + "\n" + commentStart));
+}
+
+async function listIssueComments(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">, target: IssueTarget) {
+  return (await context.octokit.paginate(context.octokit.rest.issues.listComments, {
+    owner: target.owner,
+    repo: target.repo,
+    issue_number: target.issueNumber,
+  })) as IssueCommentSummary[];
+}
+
+async function cleanupDuplicateMatchmakingComments(
+  context: Context<"issues.opened" | "issues.edited" | "issues.labeled">,
+  target: IssueTarget,
+  commentStart: string,
+  body?: string
+) {
+  const matchingComments = (await listIssueComments(context, target)).filter((comment) => isMatchmakingComment(commentStart, comment));
+
+  if (matchingComments.length === 0) {
+    return null;
+  }
+
+  const [commentToKeep, ...duplicates] = matchingComments.sort((a, b) => a.id - b.id);
+
+  if (body && commentToKeep.body !== body) {
+    await context.octokit.rest.issues.updateComment({
+      owner: target.owner,
+      repo: target.repo,
+      comment_id: commentToKeep.id,
+      body,
+    });
+  }
+
+  await Promise.all(
+    duplicates.map((comment) =>
+      context.octokit.rest.issues.deleteComment({
+        owner: target.owner,
+        repo: target.repo,
+        comment_id: comment.id,
+      })
+    )
+  );
+
+  return commentToKeep;
 }
 
 export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
   const { logger, octokit, payload } = context;
   const issue = payload.issue;
   const commentStart = ">The following contributors may be suitable for this task:";
+  const target = {
+    owner: payload.repository.owner.login,
+    repo: payload.repository.name,
+    issueNumber: issue.number,
+  };
 
   const result = await issueMatching(context);
 
@@ -49,23 +108,24 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
   const { matchResultArray, sortedContributors } = result;
 
   // Fetch if any previous comment exists
-  const listIssues = (await octokit.paginate(octokit.rest.issues.listComments, {
-    owner: payload.repository.owner.login,
-    repo: payload.repository.name,
-    issue_number: issue.number,
-  })) as IssueCommentSummary[];
+  const listIssues = await listIssueComments(context, target);
 
   //Check if the comment already exists
-  const existingComment = listIssues.find((comment) => comment.body && comment.body.includes(">[!NOTE]" + "\n" + commentStart));
+  const existingComment = listIssues.find((comment) => isMatchmakingComment(commentStart, comment));
 
   if (matchResultArray.size === 0) {
     if (existingComment) {
-      // If the comment already exists, delete it
-      await octokit.rest.issues.deleteComment({
-        owner: payload.repository.owner.login,
-        repo: payload.repository.name,
-        comment_id: existingComment.id,
-      });
+      await Promise.all(
+        listIssues
+          .filter((comment) => isMatchmakingComment(commentStart, comment))
+          .map((comment) =>
+            octokit.rest.issues.deleteComment({
+              owner: target.owner,
+              repo: target.repo,
+              comment_id: comment.id,
+            })
+          )
+      );
     }
     logger.debug("No suitable contributors found");
     return;
@@ -80,19 +140,15 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
   logger.debug("Comment to be added", { comment });
 
   if (existingComment) {
-    await context.octokit.rest.issues.updateComment({
-      owner: payload.repository.owner.login,
-      repo: payload.repository.name,
-      comment_id: existingComment.id,
-      body: comment,
-    });
+    await cleanupDuplicateMatchmakingComments(context, target, commentStart, comment);
   } else {
     await context.octokit.rest.issues.createComment({
-      owner: payload.repository.owner.login,
-      repo: payload.repository.name,
-      issue_number: payload.issue.number,
+      owner: target.owner,
+      repo: target.repo,
+      issue_number: target.issueNumber,
       body: comment,
     });
+    await cleanupDuplicateMatchmakingComments(context, target, commentStart, comment);
   }
 }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -329,6 +329,77 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("98% Match");
   });
 
+  it("When issue matching finds duplicate recommendation comments, it should keep one updated comment", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_duplicates", 13, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.createIssue = mock(async () => {
+      createIssue(
+        taskCompleteIssue.issue_body,
+        "task_complete_duplicates",
+        taskCompleteIssue.title,
+        13,
+        { login: "test", id: 1 },
+        "open",
+        null,
+        STRINGS.TEST_REPO,
+        STRINGS.USER_1
+      );
+    });
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { issue_id: "task_complete_duplicates", similarity: 0.98 },
+    ] as unknown as IssueSimilaritySearchResult[]);
+
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Similar Issue: Suggest based on Similarity",
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: "contributor1", url: "https://github.com/contributor1" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    const duplicateComment = `>[!NOTE]\n>${STRINGS.CONTRIBUTOR_SUGGESTION_TEXT}\n>### [old](https://www.github.com/old)`;
+    createComment(duplicateComment, 10, "task_complete_duplicates", 13);
+    createComment(duplicateComment, 11, "task_complete_duplicates", 13);
+
+    context.octokit.paginate = mock(async () =>
+      db.issueComments.findMany({ where: { issue_number: { equals: 13 } } })
+    ) as unknown as typeof context.octokit.paginate;
+
+    context.octokit.rest.issues.updateComment = mock(async (params: { comment_id: number; body: string }) => {
+      db.issueComments.update({
+        where: {
+          id: { equals: params.comment_id },
+        },
+        data: {
+          body: params.body,
+        },
+      });
+    }) as unknown as typeof octokit.rest.issues.updateComment;
+
+    context.octokit.rest.issues.deleteComment = mock(async (params: { comment_id: number }) => {
+      db.issueComments.delete({
+        where: {
+          id: { equals: params.comment_id },
+        },
+      });
+    }) as unknown as typeof octokit.rest.issues.deleteComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { issue_number: { equals: 13 } } });
+    expect(comments.length).toBe(1);
+    expect(comments[0].id).toBe(10);
+    expect(comments[0].body).toContain(STRINGS.CONTRIBUTOR_SUGGESTION_TEXT);
+    expect(comments[0].body).toContain("contributor1");
+    expect(comments[0].body).toContain("98% Match");
+  });
+
   it("When issue matching is triggered with alwaysRecommend enabled, it should suggest contributors regardless of similarity", async () => {
     const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
     const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_always", 6, taskCompleteIssue.title);


### PR DESCRIPTION
Resolves duplicate matchmaking recommendation comments created by concurrent issue label/opened webhook runs.

Summary:
- centralizes matchmaking comment detection for the recommendation note
- updates one canonical existing recommendation comment and removes duplicate copies
- runs the same cleanup after creating a new comment so concurrent creates converge back to one note
- deletes all recommendation notes when no suitable contributors remain
- adds a regression test for duplicate recommendation comments

Testing:
- `bun install --frozen-lockfile --ignore-scripts`
- `bun test tests/main.test.ts -t "duplicate recommendation"`
- `bun test tests/main.test.ts --silent` (15 pass)
- `bun run build` (`tsc --noEmit`; manifest tool warning only: missing `npx` for optional formatting)
- `bunx prettier --check src/handlers/issue-matching.ts tests/main.test.ts`
- `bunx eslint src/handlers/issue-matching.ts tests/main.test.ts`

Closes #94