### PR TITLE
fix: mark duplicate issues formally

### DIFF
--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -10,6 +10,7 @@ import { findEditDistance } from "../utils/string-similarity";
 
 export interface IssueGraphqlResponse {
   node: {
+    id: string;
     title: string;
     number: number;
     url: string;
@@ -23,6 +24,21 @@ export interface IssueGraphqlResponse {
   };
   similarity: string;
   mostSimilarSentence: { sentence: string; similarity: number; index: number };
+}
+
+interface CloseIssueAsDuplicateResponse {
+  closeIssue: {
+    issue: {
+      id: string;
+      number: number;
+      stateReason: string | null;
+      duplicateOf: {
+        id: string;
+        number: number;
+        url: string;
+      } | null;
+    };
+  };
 }
 
 /**
@@ -74,24 +90,28 @@ export async function issueDedupe(context: Context<"issues.opened" | "issues.edi
     const matchIssues = processedIssues.filter((issue) => parseFloat(issue.similarity) / 100 >= context.config.dedupeMatchThreshold);
     if (matchIssues.length > 0) {
       logger.info(`Similar issue which matches more than ${context.config.dedupeMatchThreshold} already exists`, { matchIssues });
+      const canonicalDuplicateIssue = matchIssues.toSorted((a, b) => parseFloat(b.similarity) - parseFloat(a.similarity))[0];
       //To the issue body, add a footnote with the link to the similar issue
       const updatedBody = await handleMatchIssuesComment(context, payload, cleanedIssueBody, processedIssues);
       const outputBody = updatedBody || cleanedIssueBody;
       const nextBody = updateComment ? appendPluginUpdateComment(outputBody, updateComment) : outputBody;
       const isBodyUnchanged = normalizeWhitespace(originalIssue.body ?? "") === normalizeWhitespace(nextBody);
-      const shouldClose = originalIssue.state !== "closed" || originalIssue.state_reason !== "not_planned";
-      if (isBodyUnchanged && !shouldClose) {
+      const shouldCloseAsDuplicate = originalIssue.state !== "closed" || originalIssue.state_reason !== "duplicate";
+      if (isBodyUnchanged && !shouldCloseAsDuplicate) {
         logger.info("Issue body unchanged after dedupe match update", { issueNumber: originalIssue.number });
         return;
       }
-      await octokit.rest.issues.update({
-        owner: payload.repository.owner.login,
-        repo: payload.repository.name,
-        issue_number: originalIssue.number,
-        body: nextBody,
-        state: "closed",
-        state_reason: "not_planned",
-      });
+      if (!isBodyUnchanged) {
+        await octokit.rest.issues.update({
+          owner: payload.repository.owner.login,
+          repo: payload.repository.name,
+          issue_number: originalIssue.number,
+          body: nextBody,
+        });
+      }
+      if (shouldCloseAsDuplicate) {
+        await closeIssueAsDuplicate(context, canonicalDuplicateIssue);
+      }
       return;
     }
     if (processedIssues.length > 0) {
@@ -117,6 +137,43 @@ export async function issueDedupe(context: Context<"issues.opened" | "issues.edi
     }
   }
   context.logger.info("No similar issues found");
+}
+
+async function closeIssueAsDuplicate(context: Context<"issues.opened" | "issues.edited">, canonicalIssue: IssueGraphqlResponse) {
+  const {
+    logger,
+    octokit,
+    payload: { issue: duplicateIssue },
+  } = context;
+
+  const response = await octokit.graphql<CloseIssueAsDuplicateResponse>(
+    /* GraphQL */
+    `
+      mutation CloseIssueAsDuplicate($issueId: ID!, $duplicateIssueId: ID!) {
+        closeIssue(input: { issueId: $issueId, stateReason: DUPLICATE, duplicateIssueId: $duplicateIssueId }) {
+          issue {
+            id
+            number
+            stateReason
+            duplicateOf {
+              id
+              number
+              url
+            }
+          }
+        }
+      }
+    `,
+    {
+      issueId: duplicateIssue.node_id,
+      duplicateIssueId: canonicalIssue.node.id,
+    }
+  );
+
+  logger.info("Issue closed as a formal duplicate", {
+    issueNumber: duplicateIssue.number,
+    duplicateOf: response.closeIssue.issue.duplicateOf?.url,
+  });
 }
 
 function matchRepoOrgToSimilarIssueRepoOrg(repoOrg: string, similarIssueRepoOrg: string, repoName: string, similarIssueRepoName: string): boolean {
@@ -290,6 +347,7 @@ export async function processSimilarIssues(similarIssues: IssueSimilaritySearchR
             query ($issueNodeId: ID!) {
               node(id: $issueNodeId) {
                 ... on Issue {
+                  id
                   title
                   url
                   number

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -205,6 +205,7 @@ describe("Plugin tests", () => {
 
   it("When an issue is created with similarity above match threshold, it should close the issue and add a caution alert", async () => {
     const [matchThresholdIssue1, matchThresholdIssue2] = fetchSimilarIssues("match_threshold_95");
+    const similarIssueUrl = "https://github.com/ubiquity/test-repo/issues/3";
     const { context } = createContextIssues(matchThresholdIssue1.issue_body, "match1", 3, matchThresholdIssue1.title);
     context.eventName = ISSUES_EDITED_EVENT_NAME;
     context.adapters.supabase.issue.findSimilarIssues = mock().mockResolvedValue([]);
@@ -229,20 +230,50 @@ describe("Plugin tests", () => {
     context2.adapters.supabase.issue.findSimilarIssues = mock().mockResolvedValue([
       { issue_id: "match1", similarity: 0.96 },
     ] as unknown as IssueSimilaritySearchResult[]);
-    context2.octokit.graphql = mock().mockResolvedValue({
-      node: {
-        title: STRINGS.SIMILAR_ISSUE,
-        url: STRINGS.ISSUE_URL,
-        number: 3,
-        lastEditedAt: "2020-01-12T17:52:02Z",
-        body: matchThresholdIssue1.issue_body,
-        repository: {
-          name: STRINGS.TEST_REPO,
-          owner: {
-            login: STRINGS.USER_1,
+    context2.octokit.graphql = mock(async (query: string, variables: { issueId?: string; duplicateIssueId?: string }) => {
+      if (query.includes("mutation CloseIssueAsDuplicate")) {
+        db.issue.update({
+          where: {
+            node_id: { equals: variables.issueId ?? "" },
+          },
+          data: {
+            state: "closed",
+            state_reason: "duplicate",
+          },
+        });
+
+        return {
+          closeIssue: {
+            issue: {
+              id: variables.issueId,
+              number: 4,
+              stateReason: "DUPLICATE",
+              duplicateOf: {
+                id: variables.duplicateIssueId,
+                number: 3,
+                url: similarIssueUrl,
+              },
+            },
+          },
+        };
+      }
+
+      return {
+        node: {
+          id: "match1",
+          title: STRINGS.SIMILAR_ISSUE,
+          url: similarIssueUrl,
+          number: 3,
+          lastEditedAt: "2020-01-12T17:52:02Z",
+          body: matchThresholdIssue1.issue_body,
+          repository: {
+            name: STRINGS.TEST_REPO,
+            owner: {
+              login: STRINGS.USER_1,
+            },
           },
         },
-      },
+      };
     }) as unknown as typeof context2.octokit.graphql;
 
     context2.adapters.supabase.issue.createIssue = mock(async () => {
@@ -259,29 +290,24 @@ describe("Plugin tests", () => {
       );
     });
 
-    context2.octokit.rest.issues.update = mock(
-      async (params: { owner: string; repo: string; issue_number: number; body?: string; state?: string; state_reason?: string }) => {
-        const updatedBody = `${matchThresholdIssue2.issue_body}\n\n>[!CAUTION]\n> This issue may be a duplicate of the following issues:\n> - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n`;
-        db.issue.update({
-          where: {
-            number: { equals: params.issue_number },
-          },
-          data: {
-            ...(params.body && { body: updatedBody }),
-            ...(params.state && { state: params.state }),
-            ...(params.state_reason && { state_reason: params.state_reason }),
-          },
-        });
-      }
-    ) as unknown as typeof octokit.rest.issues.update;
+    context2.octokit.rest.issues.update = mock(async (params: { owner: string; repo: string; issue_number: number; body?: string }) => {
+      db.issue.update({
+        where: {
+          number: { equals: params.issue_number },
+        },
+        data: {
+          ...(params.body && { body: params.body }),
+        },
+      });
+    }) as unknown as typeof octokit.rest.issues.update;
 
     await runPlugin(context2);
     const issue = db.issue.findFirst({ where: { number: { equals: 4 } } }) as unknown as Context["payload"]["issue"];
     expect(issue.state).toBe("closed");
-    expect(issue.state_reason).toBe("not_planned");
+    expect(issue.state_reason).toBe("duplicate");
     expect(issue.body).toContain(">[!CAUTION]");
     expect(issue.body).toContain("This issue may be a duplicate of the following issues:");
-    expect(issue.body).toContain(`- [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    expect(issue.body).toContain(`- [${STRINGS.SIMILAR_ISSUE}](https://www.github.com/ubiquity/test-repo/issues/3#3)`);
   });
 
   it("When issue matching is triggered, it should suggest contributors based on similarity", async () => {


### PR DESCRIPTION
## Summary
- close high-confidence duplicate matches with GitHub's formal `closeIssue` GraphQL mutation
- pass the canonical duplicate issue node ID through the existing similar-issue lookup
- keep the caution body update separate from the duplicate close mutation

## Testing
- `npx tsc --noEmit`
- `npx eslint src/handlers/issue-deduplication.ts tests/main.test.ts`
- `npx bun test tests/main.test.ts --timeout 30000`

Closes #74