### PR TITLE
fix: dedupe matchmaking comments

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -31,14 +31,91 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+const MATCHMAKING_COMMENT_START = ">The following contributors may be suitable for this task:";
+const MATCHMAKING_COMMENT_MARKER = `>[!NOTE]\n${MATCHMAKING_COMMENT_START}`;
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
 }
 
+function isMatchmakingComment(comment: IssueCommentSummary) {
+  return Boolean(comment.body?.includes(MATCHMAKING_COMMENT_MARKER));
+}
+
+async function listMatchmakingComments(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
+  const { octokit, payload } = context;
+  const comments = (await octokit.paginate(octokit.rest.issues.listComments, {
+    owner: payload.repository.owner.login,
+    repo: payload.repository.name,
+    issue_number: payload.issue.number,
+  })) as IssueCommentSummary[];
+
+  return comments.filter(isMatchmakingComment).sort((a, b) => a.id - b.id);
+}
+
+async function deleteMatchmakingComments(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">, comments: IssueCommentSummary[]) {
+  const { octokit, payload } = context;
+  for (const comment of comments) {
+    await octokit.rest.issues.deleteComment({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      comment_id: comment.id,
+    });
+  }
+}
+
+async function syncMatchmakingComment(
+  context: Context<"issues.opened" | "issues.edited" | "issues.labeled">,
+  body: string | null,
+  shouldCreateComment: boolean
+) {
+  const { octokit, payload, logger } = context;
+  const existingComments = await listMatchmakingComments(context);
+  const [canonicalComment, ...duplicateComments] = existingComments;
+
+  if (!body) {
+    await deleteMatchmakingComments(context, existingComments);
+    return;
+  }
+
+  if (canonicalComment) {
+    await octokit.rest.issues.updateComment({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      comment_id: canonicalComment.id,
+      body,
+    });
+    await deleteMatchmakingComments(context, duplicateComments);
+    return;
+  }
+
+  if (!shouldCreateComment) {
+    logger.debug("Skipping matchmaking comment creation for non-creation event");
+    return;
+  }
+
+  await octokit.rest.issues.createComment({
+    owner: payload.repository.owner.login,
+    repo: payload.repository.name,
+    issue_number: payload.issue.number,
+    body,
+  });
+
+  const commentsAfterCreate = await listMatchmakingComments(context);
+  const [commentToKeep, ...commentsToDelete] = commentsAfterCreate;
+  if (commentToKeep && commentsToDelete.length > 0) {
+    await octokit.rest.issues.updateComment({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      comment_id: commentToKeep.id,
+      body,
+    });
+    await deleteMatchmakingComments(context, commentsToDelete);
+  }
+}
+
 export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
-  const { logger, octokit, payload } = context;
-  const issue = payload.issue;
-  const commentStart = ">The following contributors may be suitable for this task:";
+  const { logger } = context;
 
   const result = await issueMatching(context);
 
@@ -48,25 +125,8 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
 
   const { matchResultArray, sortedContributors } = result;
 
-  // Fetch if any previous comment exists
-  const listIssues = (await octokit.paginate(octokit.rest.issues.listComments, {
-    owner: payload.repository.owner.login,
-    repo: payload.repository.name,
-    issue_number: issue.number,
-  })) as IssueCommentSummary[];
-
-  //Check if the comment already exists
-  const existingComment = listIssues.find((comment) => comment.body && comment.body.includes(">[!NOTE]" + "\n" + commentStart));
-
   if (matchResultArray.size === 0) {
-    if (existingComment) {
-      // If the comment already exists, delete it
-      await octokit.rest.issues.deleteComment({
-        owner: payload.repository.owner.login,
-        repo: payload.repository.name,
-        comment_id: existingComment.id,
-      });
-    }
+    await syncMatchmakingComment(context, null, false);
     logger.debug("No suitable contributors found");
     return;
   }
@@ -79,21 +139,7 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
 
   logger.debug("Comment to be added", { comment });
 
-  if (existingComment) {
-    await context.octokit.rest.issues.updateComment({
-      owner: payload.repository.owner.login,
-      repo: payload.repository.name,
-      comment_id: existingComment.id,
-      body: comment,
-    });
-  } else {
-    await context.octokit.rest.issues.createComment({
-      owner: payload.repository.owner.login,
-      repo: payload.repository.name,
-      issue_number: payload.issue.number,
-      body: comment,
-    });
-  }
+  await syncMatchmakingComment(context, comment, context.eventName !== "issues.labeled");
 }
 
 type IssueMatchingEvents = "issues.opened" | "issues.edited" | "issues.labeled" | "issue_comment.created";
@@ -286,7 +332,7 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
  * @returns The comment to be added to the issue
  */
 function commentBuilder(matchResultArray: Map<string, Array<string>>): string {
-  const commentLines: string[] = [">[!NOTE]", ">The following contributors may be suitable for this task:"];
+  const commentLines: string[] = [">[!NOTE]", MATCHMAKING_COMMENT_START];
   matchResultArray.forEach((issues: Array<string>, assignee: string) => {
     commentLines.push(`>### [${assignee}](https://www.github.com/${assignee})`);
     issues.forEach((issue: string) => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -20,6 +20,9 @@ const DEFAULT_HOOK = "issue_comment.created";
 const DEFAULT_ISSUE_ID = "1";
 const DEFAULT_BODY = "Test issue body";
 const ISSUES_EDITED_EVENT_NAME = "issues.edited";
+const SIMILAR_MATCH_TITLE = "Similar Issue: Suggest based on Similarity";
+const CONTRIBUTOR_1 = "contributor1";
+const CONTRIBUTOR_1_URL = `https://github.com/${CONTRIBUTOR_1}`;
 
 dotenv.config();
 const octokit = new Octokit();
@@ -306,13 +309,13 @@ describe("Plugin tests", () => {
     // Mock the graphql function to return predefined issue data
     context.octokit.graphql = mock().mockResolvedValue({
       node: {
-        title: "Similar Issue: Suggest based on Similarity",
+        title: SIMILAR_MATCH_TITLE,
         url: STRINGS.ISSUE_URL_TEMPLATE,
         state: "closed",
         stateReason: "COMPLETED",
         closed: true,
         repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
-        assignees: { nodes: [{ login: "contributor1", url: "https://github.com/contributor1" }] },
+        assignees: { nodes: [{ login: CONTRIBUTOR_1, url: CONTRIBUTOR_1_URL }] },
       },
     }) as unknown as typeof context.octokit.graphql;
 
@@ -325,7 +328,7 @@ describe("Plugin tests", () => {
     const comments = db.issueComments.findMany({ where: { node_id: { equals: "task_complete" } } });
     expect(comments.length).toBe(1);
     expect(comments[0].body).toContain(STRINGS.CONTRIBUTOR_SUGGESTION_TEXT);
-    expect(comments[0].body).toContain("contributor1");
+    expect(comments[0].body).toContain(CONTRIBUTOR_1);
     expect(comments[0].body).toContain("98% Match");
   });
 
@@ -379,6 +382,117 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain(STRINGS.CONTRIBUTOR_SUGGESTION_TEXT);
     expect(comments[0].body).toContain("contributor3");
     expect(comments[0].body).toContain("50% Match");
+  });
+
+  it("When duplicate matchmaking comments exist it should update one and delete the rest", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const issueNodeId = "duplicate_matching_comment";
+    const issueNumber = 11;
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, issueNodeId, issueNumber, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    const duplicateCommentBody = ">[!NOTE]\n>The following contributors may be suitable for this task:\n>### [old](https://www.github.com/old)";
+    createComment(duplicateCommentBody, 41, issueNodeId, issueNumber);
+    createComment(duplicateCommentBody, 42, issueNodeId, issueNumber);
+
+    context.adapters.supabase.issue.createIssue = mock(async () => {
+      createIssue(
+        taskCompleteIssue.issue_body,
+        issueNodeId,
+        taskCompleteIssue.title,
+        issueNumber,
+        { login: "test", id: 1 },
+        "open",
+        null,
+        STRINGS.TEST_REPO,
+        STRINGS.USER_1
+      );
+    });
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { issue_id: "similar3", similarity: 0.98 },
+    ] as unknown as IssueSimilaritySearchResult[]);
+
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: SIMILAR_MATCH_TITLE,
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: CONTRIBUTOR_1, url: CONTRIBUTOR_1_URL }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.paginate = mock(async () =>
+      db.issueComments.findMany({ where: { issue_number: { equals: issueNumber } } }).map((comment) => ({
+        id: comment.id,
+        body: comment.body,
+      }))
+    ) as unknown as typeof octokit.paginate;
+    context.octokit.rest.issues.createComment = mock(async () => {
+      throw new Error("Existing matchmaking comments should be updated, not recreated");
+    }) as unknown as typeof octokit.rest.issues.createComment;
+    context.octokit.rest.issues.updateComment = mock(async (params: { comment_id: number; body: string }) => {
+      db.issueComments.update({
+        where: { id: { equals: params.comment_id } },
+        data: { body: params.body },
+      });
+    }) as unknown as typeof octokit.rest.issues.updateComment;
+    context.octokit.rest.issues.deleteComment = mock(async (params: { comment_id: number }) => {
+      db.issueComments.delete({
+        where: { id: { equals: params.comment_id } },
+      });
+    }) as unknown as typeof octokit.rest.issues.deleteComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { issue_number: { equals: issueNumber } } });
+    expect(comments.length).toBe(1);
+    expect(comments[0].id).toBe(41);
+    expect(comments[0].body).toContain(STRINGS.CONTRIBUTOR_SUGGESTION_TEXT);
+    expect(comments[0].body).toContain(CONTRIBUTOR_1);
+    expect(comments[0].body).toContain("98% Match");
+  });
+
+  it("When issue matching is triggered by a label event without an existing comment it should not create one", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const issueNodeId = "labeled_matching_comment";
+    const issueNumber = 12;
+    const { context } = createContextIssues(
+      taskCompleteIssue.issue_body,
+      issueNodeId,
+      issueNumber,
+      taskCompleteIssue.title,
+      { login: "test", id: 1 },
+      "open",
+      null,
+      "issues.labeled"
+    );
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { issue_id: "similar3", similarity: 0.98 },
+    ] as unknown as IssueSimilaritySearchResult[]);
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: SIMILAR_MATCH_TITLE,
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: CONTRIBUTOR_1, url: CONTRIBUTOR_1_URL }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+    context.octokit.paginate = mock(async () => []) as unknown as typeof octokit.paginate;
+    context.octokit.rest.issues.createComment = mock(async () => {
+      throw new Error("Label events should not create the first matchmaking comment");
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { issue_number: { equals: issueNumber } } });
+    expect(comments.length).toBe(0);
   });
 
   it("When an issue contains markdown links, footnotes should be added after the entire line", async () => {


### PR DESCRIPTION
Fixes #94.

## Summary
- Treat the matchmaking recommendation comment as a single canonical comment and delete duplicates when syncing.
- Skip first-time matchmaking comment creation on `issues.labeled` events so label-triggered concurrent jobs can only update an existing comment.
- Add regression coverage for duplicate cleanup and label-triggered no-create behavior.

## Validation
- `bun test`
- `bun run build`
- `git diff --check`