### PR TITLE
fix: clarify annotate errors outside org

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -23,7 +23,12 @@ interface CommentGraphqlResponse {
   mostSimilarSentence: { sentence: string; similarity: number; index: number };
 }
 
-export async function annotate(context: Context<"issue_comment.created">, commentId: string | null, scope: string) {
+export async function annotate(
+  context: Context<"issue_comment.created">,
+  commentId: string | null,
+  scope: string,
+  commentRepo?: { owner: string; repo: string }
+) {
   const { logger, octokit, payload } = context;
 
   const repository = payload.repository;
@@ -43,9 +48,18 @@ export async function annotate(context: Context<"issue_comment.created">, commen
       logger.error("No comments before the annotate command");
     }
   } else {
+    const commentOwner = commentRepo?.owner ?? repository.owner.login;
+    const commentRepository = commentRepo?.repo ?? repository.name;
+
+    if (scope !== "global" && commentOwner !== repository.owner.login) {
+      throw logger.error(
+        `Cannot annotate comment from ${commentOwner}/${commentRepository} with ${scope} scope. Use a comment from ${repository.owner.login} or run /annotate with global scope.`
+      );
+    }
+
     const { data } = await octokit.rest.issues.getComment({
-      owner: repository.owner.login,
-      repo: repository.name,
+      owner: commentOwner,
+      repo: commentRepository,
       comment_id: parseInt(commentId, 10),
     });
     await commentChecker(context, data, scope);

--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -45,6 +45,20 @@ async function postCommandResponse(context: Context<"issue_comment.created">, bo
   await context.commentHandler.postComment(context, context.logger.info(body), options);
 }
 
+function parseGitHubCommentUrl(commentUrl: string): { owner: string; repo: string; commentId: string } | null {
+  const match = commentUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/\d+#issuecomment-(\d+)$/);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    owner: match[1],
+    repo: match[2],
+    commentId: match[3],
+  };
+}
+
 export async function commandHandler(context: Context<"issue_comment.created">) {
   const { logger } = context;
 
@@ -56,15 +70,16 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
     const commentUrl = context.command.parameters.commentUrl ?? null;
     const scope = context.command.parameters.scope ?? "org";
     let commentId = null;
+    let commentRepo;
     if (commentUrl) {
-      const commentRegex = /#issuecomment-(\d+)$/;
-      const match = commentUrl.match(commentRegex);
-      if (!match) {
+      const parsedComment = parseGitHubCommentUrl(commentUrl);
+      if (!parsedComment) {
         throw logger.error("Invalid comment URL");
       }
-      commentId = match[1];
+      commentId = parsedComment.commentId;
+      commentRepo = { owner: parsedComment.owner, repo: parsedComment.repo };
     }
-    await annotate(context, commentId, scope);
+    await annotate(context, commentId, scope, commentRepo);
   }
 }
 
@@ -76,6 +91,7 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
 
   let commentId = null;
   let scope = "org";
+  let commentRepo;
 
   if (commandName === "annotate") {
     if (splitComment.length > 1) {
@@ -87,17 +103,17 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
           throw logger.error("Invalid scope");
         }
 
-        const commentRegex = /#issuecomment-(\d+)$/;
-        const match = commentUrl.match(commentRegex);
-        if (!match) {
+        const parsedComment = parseGitHubCommentUrl(commentUrl);
+        if (!parsedComment) {
           throw logger.error("Invalid comment URL");
         }
-        commentId = match[1];
+        commentId = parsedComment.commentId;
+        commentRepo = { owner: parsedComment.owner, repo: parsedComment.repo };
       } else {
         throw logger.error("Invalid parameters");
       }
     }
-    await annotate(context, commentId, scope);
+    await annotate(context, commentId, scope, commentRepo);
   }
 
   if (commandName === "recommendation") {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -528,6 +528,47 @@ describe("Plugin tests", () => {
     expect(updatedComment.body).toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
+  it("When annotate targets a comment outside the current org with org scope, it should throw a clear permission error before fetching the comment", async () => {
+    const { context } = createContext(
+      "/annotate https://github.com/outside-org/outside-repo/issues/1#issuecomment-123 org",
+      1,
+      1,
+      2,
+      "createAnnotateOutsideOrg",
+      DEFAULT_ISSUE_ID
+    );
+
+    context.octokit.rest.issues.getComment = mock(async () => {
+      throw new Error("getComment should not be called for outside-org comments with org scope");
+    }) as unknown as typeof octokit.rest.issues.getComment;
+
+    await expect(runPlugin(context)).rejects.toMatchObject({
+      logMessage: {
+        raw: `Cannot annotate comment from outside-org/outside-repo with org scope. Use a comment from ${STRINGS.USER_1} or run /annotate with global scope.`,
+      },
+    });
+  });
+
+  it("When annotate targets a comment outside the current org with global scope, it should fetch from the parsed comment repository", async () => {
+    const { context } = createContext(
+      "/annotate https://github.com/outside-org/outside-repo/issues/1#issuecomment-123 global",
+      1,
+      1,
+      2,
+      "createAnnotateOutsideOrgGlobal",
+      DEFAULT_ISSUE_ID
+    );
+
+    context.adapters.supabase.issue.findSimilarIssues = mock().mockResolvedValue([]);
+    context.adapters.supabase.comment.findSimilarComments = mock().mockResolvedValue([]);
+    context.octokit.rest.issues.getComment = mock(async (params: { owner: string; repo: string; comment_id: number }) => {
+      expect(params).toMatchObject({ owner: "outside-org", repo: "outside-repo", comment_id: 123 });
+      return { data: annotateComment };
+    }) as unknown as typeof octokit.rest.issues.getComment;
+
+    await runPlugin(context);
+  });
+
   it("When demoFlag is true, it should skip storing issues in the database", async () => {
     const { context } = createContextIssues(DEFAULT_BODY, "demoIssue", 10, "Demo Test Issue");
 
@@ -592,7 +633,14 @@ describe("Plugin tests", () => {
 
     createComment(annotateComment.body, annotateComment.id, "annotate", 9);
 
-    const { context: context2 } = createContext("/annotate /#issuecomment-1 repo", 1, 1, 2, "createAnnotate", "annotate");
+    const { context: context2 } = createContext(
+      `/annotate https://github.com/${STRINGS.USER_1}/${STRINGS.TEST_REPO}/issues/9#issuecomment-1 repo`,
+      1,
+      1,
+      2,
+      "createAnnotate",
+      "annotate"
+    );
 
     context2.adapters.supabase.issue.findSimilarIssues = mock().mockResolvedValue([
       { issue_id: "annotate", similarity: 0.88 },


### PR DESCRIPTION
Resolves #78

## Summary
- parse full GitHub issue/pull comment URLs so annotate can target the correct comment repository
- fail fast with a clear permission/scope error when an org/repo-scoped annotation points outside the current owner
- keep global-scope annotations working by fetching from the parsed owner/repo

## Verification
- npx tsc --noEmit
- npx bun test tests/main.test.ts