### PR TITLE
fix: address March 2025 review adjustments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "hono-rate-limiter": "^0.4.2",
         "jsdom": "^26.1.0",
         "marked": "^16.2.0",
+        "ms": "^2.1.3",
         "quansync": "^0.2.11",
         "valibot": "1.2.0",
         "voyageai": "^0.0.4",
@@ -37,6 +38,7 @@
         "@types/deno": "^2.3.0",
         "@types/he": "^1.2.3",
         "@types/jsdom": "^21.1.7",
+        "@types/ms": "^2.1.0",
         "@types/node": "20.14.5",
         "cross-env": "7.0.3",
         "cspell": "8.9.0",
@@ -461,6 +463,8 @@
     "@types/lodash": ["@types/lodash@4.17.23", "", {}, "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA=="],
 
     "@types/md5": ["@types/md5@2.3.6", "", {}, "sha512-WD69gNXtRBnpknfZcb4TRQ0XJQbUPZcai/Qdhmka3sxUR3Et8NrXoeAoknG/LghYHTf4ve795rInVYHBTQdNVA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@20.14.5", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA=="],
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "hono-rate-limiter": "^0.4.2",
     "jsdom": "^26.1.0",
     "marked": "^16.2.0",
+    "ms": "^2.1.3",
     "quansync": "^0.2.11",
     "valibot": "1.2.0",
     "voyageai": "^0.0.4"
@@ -67,6 +68,7 @@
     "@types/deno": "^2.3.0",
     "@types/he": "^1.2.3",
     "@types/jsdom": "^21.1.7",
+    "@types/ms": "^2.1.0",
     "@types/node": "20.14.5",
     "cross-env": "7.0.3",
     "cspell": "8.9.0",

--- a/src/adapters/supabase/helpers/comment.ts
+++ b/src/adapters/supabase/helpers/comment.ts
@@ -64,7 +64,7 @@ export class Comment extends SuperSupabase {
       .in("doc_type", COMMENT_DOCUMENT_TYPES);
     if (existingError) {
       this.context.logger.error("Error creating comment", {
-        Error: existingError,
+        error: existingError,
         commentData,
       });
       return;
@@ -100,7 +100,7 @@ export class Comment extends SuperSupabase {
     ]);
     if (error) {
       this.context.logger.error("Failed to create comment in database", {
-        Error: error,
+        error,
         commentData,
       });
       return;
@@ -148,7 +148,7 @@ export class Comment extends SuperSupabase {
         .in("doc_type", COMMENT_DOCUMENT_TYPES);
       if (error) {
         this.context.logger.error("Error updating comment", {
-          Error: error,
+          error,
           commentData: {
             commentData,
             markdown: finalMarkdown,
@@ -180,7 +180,7 @@ export class Comment extends SuperSupabase {
       .is("deleted_at", null);
     if (error) {
       this.context.logger.error("Error getting comment", {
-        Error: error,
+        error,
         commentData: {
           id: commentNodeId,
         },
@@ -198,7 +198,7 @@ export class Comment extends SuperSupabase {
       .in("doc_type", COMMENT_DOCUMENT_TYPES);
     if (error) {
       this.context.logger.error("Error deleting comment", {
-        Error: error,
+        error,
         commentData: {
           id: commentNodeId,
         },
@@ -233,7 +233,7 @@ export class Comment extends SuperSupabase {
       });
       if (error) {
         this.context.logger.error("Unable to find similar comments", {
-          Error: error,
+          error,
           markdown,
           currentId,
           threshold,
@@ -243,8 +243,9 @@ export class Comment extends SuperSupabase {
       }
       return data;
     } catch (error) {
+      const normalizedError = error instanceof Error ? error : { stack: String(error) };
       this.context.logger.error("Unable to find similar comments", {
-        Error: error,
+        error: normalizedError,
         markdown,
         currentId,
         threshold,

--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -5,6 +5,14 @@ import { CommentSimilaritySearchResult } from "../adapters/supabase/helpers/comm
 import { stripHtmlComments } from "../utils/markdown-comments";
 import { appendFootnoteRefsToFirstLine, insertFootnoteRefNearSentence } from "../utils/footnote-placement";
 
+const ANNOTATION_ISSUE_FOOTNOTE_PREFIX = "annotation-issue-";
+const ANNOTATION_COMMENT_FOOTNOTE_PREFIX = "annotation-comment-";
+
+function formatGitHubIssueUrl(url: string, issueNumber: string | number): string {
+  const modifiedUrl = url.replace("https://github.com", "https://www.github.com");
+  return modifiedUrl.includes("#") ? modifiedUrl : `${modifiedUrl}#${issueNumber}`;
+}
+
 interface CommentGraphqlResponse {
   node: {
     body: string;
@@ -144,18 +152,21 @@ async function handleSimilarIssuesAndComments(
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
-  const existingFootnotes = commentBody.match(footnoteRegex) || [];
-  let highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn.match(/\d+/)?.[0] ?? "0"))) : 0;
+  const issueFootnoteRegex = /\[\^annotation-issue-(\d+)\^\]/g;
+  const existingIssueFootnotes = Array.from(commentBody.matchAll(issueFootnoteRegex));
+  const highestIssueFootnoteIndex = existingIssueFootnotes.length > 0 ? Math.max(...existingIssueFootnotes.map((fn) => parseInt(fn[1] ?? "0", 10))) : 0;
+  const commentFootnoteRegex = /\[\^annotation-comment-(\d+)\^\]/g;
+  const existingCommentFootnotes = Array.from(commentBody.matchAll(commentFootnoteRegex));
+  const highestCommentFootnoteIndex = existingCommentFootnotes.length > 0 ? Math.max(...existingCommentFootnotes.map((fn) => parseInt(fn[1] ?? "0", 10))) : 0;
   let updatedBody = commentBody;
   const footnotes: string[] = [];
   const orphanRefs: string[] = [];
   // Sort relevant issues by similarity in ascending order
   issueList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   issueList.forEach((issue, index) => {
-    const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
-    const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
+    const footnoteIndex = highestIssueFootnoteIndex + index + 1; // Continue numbering from the highest existing issue footnote number
+    const footnoteRef = `[^${ANNOTATION_ISSUE_FOOTNOTE_PREFIX}${footnoteIndex}^]`;
+    const modifiedUrl = formatGitHubIssueUrl(issue.node.url, issue.node.number);
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
     if (!sentence.trim()) {
@@ -178,13 +189,12 @@ async function handleSimilarIssuesAndComments(
     }
 
     // Add new footnote to the array
-    footnotes.push(`${footnoteRef}: ${issue.similarity}% similar to issue: [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n\n`);
+    footnotes.push(`${footnoteRef}: ${issue.similarity}% similar to issue: [${issue.node.title}](${modifiedUrl})\n\n`);
   });
-  highestFootnoteIndex += footnotes.length;
   commentList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   commentList.forEach((comment, index) => {
-    const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteIndex = highestCommentFootnoteIndex + index + 1; // Continue numbering from the highest existing comment footnote number
+    const footnoteRef = `[^${ANNOTATION_COMMENT_FOOTNOTE_PREFIX}${footnoteIndex}^]`;
     const modifiedUrl = comment.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = comment.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -277,7 +287,7 @@ async function processSimilarComments(
  * @returns True if a annotate footnote exists, false otherwise
  */
 export function checkIfAnnotateFootNoteExists(content: string): boolean {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
+  const footnoteDefRegex = /\[\^((?:annotation-(?:issue|comment)-)?\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
   const footnotes = content.match(footnoteDefRegex);
   return !!footnotes;
 }
@@ -289,13 +299,16 @@ export function checkIfAnnotateFootNoteExists(content: string): boolean {
  * @returns The content without footnotes
  */
 export function removeAnnotateFootnotes(content: string): string {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
+  const footnoteDefRegex = /\[\^((?:annotation-(?:issue|comment)-)?\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
   const footnotes = content.match(footnoteDefRegex);
   let contentWithoutFootnotes = content.replace(footnoteDefRegex, "");
   if (footnotes) {
     footnotes.forEach((footnote) => {
-      const footnoteNumber = footnote.match(/\d+/)?.[0];
-      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${footnoteNumber}\\^\\]`, "g"), "");
+      const footnoteId = footnote.match(/\[\^([^\]]+)\^\]/)?.[1];
+      if (!footnoteId) {
+        return;
+      }
+      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${footnoteId}\\^\\]`, "g"), "");
     });
   }
   return contentWithoutFootnotes;

--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -8,6 +8,13 @@ import { appendFootnoteRefsToFirstLine, insertFootnoteRefNearSentence } from "..
 import { stripDuplicateFootnotes } from "../utils/footnotes";
 import { findEditDistance } from "../utils/string-similarity";
 
+const DEDUPLICATION_FOOTNOTE_PREFIX = "deduplication-";
+
+function formatGitHubIssueUrl(url: string, issueNumber: number): string {
+  const modifiedUrl = url.replace("https://github.com", "https://www.github.com");
+  return modifiedUrl.includes("#") ? modifiedUrl : `${modifiedUrl}#${issueNumber}`;
+}
+
 export interface IssueGraphqlResponse {
   node: {
     title: string;
@@ -186,17 +193,16 @@ async function handleSimilarIssuesComment(
   );
 
   if (relevantIssues.length === 0) {
-    context.logger.info("No relevant issues found with the same repository and organization");
-    return;
+    throw context.logger.info("No relevant issues found with the same repository and organization");
   }
 
   if (!issueBody) {
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
-  const existingFootnotes = issueBody.match(footnoteRegex) || [];
-  const highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn.match(/\d+/)?.[0] ?? "0"))) : 0;
+  const footnoteRegex = /\[\^deduplication-(\d+)\^\]/g;
+  const existingFootnotes = Array.from(issueBody.matchAll(footnoteRegex));
+  const highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn[1] ?? "0", 10))) : 0;
   let updatedBody = issueBody;
   const footnotes: string[] = [];
   const orphanRefs: string[] = [];
@@ -204,8 +210,8 @@ async function handleSimilarIssuesComment(
   relevantIssues.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   relevantIssues.forEach((issue, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
-    const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
+    const footnoteRef = `[^${DEDUPLICATION_FOOTNOTE_PREFIX}${footnoteIndex}^]`;
+    const modifiedUrl = formatGitHubIssueUrl(issue.node.url, issue.node.number);
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
     if (!sentence.trim()) {
@@ -228,7 +234,7 @@ async function handleSimilarIssuesComment(
     }
 
     // Add new footnote to the array
-    footnotes.push(`${footnoteRef}: ⚠ ${issue.similarity}% possible duplicate - [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n\n`);
+    footnotes.push(`${footnoteRef}: ⚠ ${issue.similarity}% possible duplicate - [${issue.node.title}](${modifiedUrl})\n\n`);
   });
   if (orphanRefs.length > 0) {
     updatedBody = appendFootnoteRefsToFirstLine(updatedBody, orphanRefs);
@@ -262,7 +268,7 @@ async function handleMatchIssuesComment(
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
+  const footnoteRegex = /\[\^(?:deduplication-)?\d+\^\]/g;
   const existingFootnotes = issueBody.match(footnoteRegex) || [];
   // Find the index with respect to the issue body string where the footnotes start if they exist
   const footnoteIndex = existingFootnotes[0] ? issueBody.indexOf(existingFootnotes[0]) : issueBody.length;
@@ -271,8 +277,8 @@ async function handleMatchIssuesComment(
   relevantIssues.sort((a, b) => parseFloat(b.similarity) - parseFloat(a.similarity));
   // Append the similar issues to the resultBuilder
   relevantIssues.forEach((issue) => {
-    const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
-    resultBuilder += `> - [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n`;
+    const modifiedUrl = formatGitHubIssueUrl(issue.node.url, issue.node.number);
+    resultBuilder += `> - [${issue.node.title}](${modifiedUrl})\n`;
   });
   // Insert the resultBuilder into the issue body
   // Update the issue with the modified body
@@ -344,9 +350,20 @@ async function handleAnchorAndImgElements(context: Context, content: string) {
   const anchors = htmlElement.getElementsByTagName("a");
   const images = htmlElement.getElementsByTagName("img");
 
+  function hasImageExtension(url: string): boolean {
+    try {
+      return /\.(?:avif|gif|jpe?g|png|svg|webp)(?:[?#].*)?$/i.test(new URL(url).pathname);
+    } catch {
+      return false;
+    }
+  }
+
   async function processElement(element: HTMLAnchorElement | HTMLImageElement, isImage: boolean) {
     const url = isImage ? (element as HTMLImageElement).getAttribute("src") : (element as HTMLAnchorElement).getAttribute("href");
     if (!url) return;
+    if (!isImage && !hasImageExtension(url)) {
+      return;
+    }
 
     try {
       const linkResponse = await fetch(url);
@@ -401,7 +418,7 @@ export async function cleanContent(context: Context, content: string): Promise<s
  * @returns True if a duplicate footnote exists, false otherwise
  */
 export function checkIfDuplicateFootNoteExists(content: string): boolean {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
+  const footnoteDefRegex = /\[\^((?:deduplication-)?\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
   const footnotes = content.match(footnoteDefRegex);
   return !!footnotes;
 }

--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -17,6 +17,11 @@ function parseUserLoginsFromTokens(tokens: string[]): string[] {
   return normalizeUserLogins(tokens);
 }
 
+function parseIssueCommentId(commentUrl: string): string | null {
+  const match = commentUrl.trim().match(/(?:^|#)issuecomment-(\d+)(?:$|[/?#&])/);
+  return match?.[1] ?? null;
+}
+
 function buildRecommendationComment(result: NonNullable<Awaited<ReturnType<typeof issueMatching>>>, requestedLogins: string[]): string {
   const formattedLogins = requestedLogins.map((login) => `@${login}`).join(", ");
   const lines: string[] = [">[!NOTE]", requestedLogins.length > 0 ? `>Recommendation results (filtered): ${formattedLogins}` : ">Recommendation results:"];
@@ -57,12 +62,10 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
     const scope = context.command.parameters.scope ?? "org";
     let commentId = null;
     if (commentUrl) {
-      const commentRegex = /#issuecomment-(\d+)$/;
-      const match = commentUrl.match(commentRegex);
-      if (!match) {
+      commentId = parseIssueCommentId(commentUrl);
+      if (!commentId) {
         throw logger.error("Invalid comment URL");
       }
-      commentId = match[1];
     }
     await annotate(context, commentId, scope);
   }
@@ -87,12 +90,10 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
           throw logger.error("Invalid scope");
         }
 
-        const commentRegex = /#issuecomment-(\d+)$/;
-        const match = commentUrl.match(commentRegex);
-        if (!match) {
+        commentId = parseIssueCommentId(commentUrl);
+        if (!commentId) {
           throw logger.error("Invalid comment URL");
         }
-        commentId = match[1];
       } else {
         throw logger.error("Invalid parameters");
       }

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -17,7 +17,10 @@ export const pluginSettingsSchema = T.Object(
     }),
     jobMatchingThreshold: T.Number({ default: 0.75, description: "The minimum similarity score when considering users to be suitable for a job." }),
     alwaysRecommend: T.Optional(
-      T.Number({ default: 0, description: "If set to a value greater than 0, the bot will always recommend contributors, regardless of the similarity score." })
+      T.Number({
+        default: 0,
+        description: "The amount of contributors that will always be recommended regardless of the similarity score.",
+      })
     ),
     demoFlag: T.Boolean({ default: false, description: "When true, disables storing issues and comments in the database." }),
   },

--- a/src/utils/embedding-queue.ts
+++ b/src/utils/embedding-queue.ts
@@ -1,3 +1,4 @@
+import ms, { StringValue } from "ms";
 import { Env } from "../types/env";
 
 export type EmbeddingQueueSettings = {
@@ -43,11 +44,21 @@ function parseNonNegativeInt(value: string | undefined, fallback: number): numbe
   if (value === undefined) {
     return fallback;
   }
-  const parsed = Number.parseInt(value, 10);
+  const parsed = parseDurationMs(value);
   if (!Number.isFinite(parsed) || parsed < 0) {
     return fallback;
   }
   return parsed;
+}
+
+function parseDurationMs(value: string): number {
+  const trimmed = value.trim();
+  const parsedNumber = Number.parseInt(trimmed, 10);
+  if (String(parsedNumber) === trimmed) {
+    return parsedNumber;
+  }
+  const parsedDuration = ms(trimmed as StringValue);
+  return typeof parsedDuration === "number" ? parsedDuration : Number.NaN;
 }
 
 export function getEmbeddingQueueSettings(env: Env): EmbeddingQueueSettings {

--- a/src/utils/footnotes.ts
+++ b/src/utils/footnotes.ts
@@ -1,4 +1,4 @@
-const FOOTNOTE_DEF_REGEX = /\[\^(\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
+const FOOTNOTE_DEF_REGEX = /\[\^((?:deduplication-)?\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
 
 export function removeCautionMessages(content: string): string {
   const cautionRegex = />[!CAUTION]\n> This issue may be a duplicate of the following issues:\n((> - \[[^\]]+\]\([^)]+\)\n)+)/g;
@@ -10,11 +10,11 @@ export function stripDuplicateFootnotes(content: string): string {
   let contentWithoutFootnotes = content.replace(FOOTNOTE_DEF_REGEX, "");
   if (footnotes) {
     footnotes.forEach((footnote) => {
-      const footnoteNumber = footnote.match(/\d+/)?.[0];
-      if (!footnoteNumber) {
+      const footnoteId = footnote.match(/\[\^([^\]]+)\^\]/)?.[1];
+      if (!footnoteId) {
         return;
       }
-      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${footnoteNumber}\\^\\]`, "g"), "");
+      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${footnoteId}\\^\\]`, "g"), "");
     });
   }
   return removeCautionMessages(contentWithoutFootnotes);

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
 
-export const urlSchema = v.pipe(v.string(), v.url(), v.regex(/https:\/\/github\.com\/[^/]+\/[^/]+\/(issues|pull)\/\d+$/));
+export const urlSchema = v.pipe(v.string(), v.url(), v.regex(/^https:\/\/(?:www\.)?github\.com\/[^/\s]+\/[^/\s]+\/(?:issues|pull)\/\d+\/?(?:[?#].*)?$/));
 
 export const querySchema = v.object({
   issueUrls: v.union([v.array(urlSchema), urlSchema]),

--- a/tests/embedding-queue.test.ts
+++ b/tests/embedding-queue.test.ts
@@ -3,6 +3,7 @@ import { SupabaseClient } from "@supabase/supabase-js";
 import { processPendingEmbeddings } from "../src/cron/embedding-queue";
 import { Database } from "../src/types/database";
 import { Env } from "../src/types/index";
+import { getEmbeddingQueueSettings } from "../src/utils/embedding-queue";
 
 type QueueRow = {
   id: string;
@@ -64,6 +65,22 @@ function createLogger() {
 }
 
 describe("processPendingEmbeddings", () => {
+  it("parses human-friendly queue delay durations", () => {
+    const settings = getEmbeddingQueueSettings({
+      EMBEDDINGS_QUEUE_DELAY_MS: "2s",
+    } as Env);
+
+    expect(settings.delayMs).toBe(2000);
+  });
+
+  it("keeps numeric queue delays backward compatible", () => {
+    const settings = getEmbeddingQueueSettings({
+      EMBEDDINGS_QUEUE_DELAY_MS: "250",
+    } as Env);
+
+    expect(settings.delayMs).toBe(250);
+  });
+
   it("processes pull request documents with issue-length thresholds", async () => {
     const env = {
       EMBEDDINGS_QUEUE_ENABLED: "true",

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -180,17 +180,12 @@ describe("Plugin tests", () => {
       });
 
       context2.octokit.rest.issues.update = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
-        // Find the most similar sentence (first sentence in this case)
-        const updatedBody =
-          warningThresholdIssue2.issue_body.replace(STRINGS.SIMILAR_ISSUE_TITLE, `${STRINGS.SIMILAR_ISSUE_TITLE}[^01^]`) +
-          `\n\n[^01^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
-
         db.issue.update({
           where: {
             number: { equals: params.issue_number },
           },
           data: {
-            body: updatedBody,
+            body: params.body,
           },
         });
       }) as unknown as typeof octokit.rest.issues.update;
@@ -199,7 +194,9 @@ describe("Plugin tests", () => {
 
       const issue = db.issue.findFirst({ where: { node_id: { equals: "warning2" } } }) as unknown as Context["payload"]["issue"];
       expect(issue.state).toBe("open");
-      expect(issue.body).toContain(`[^01^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+      expect(issue.body).toContain(
+        `[^deduplication-1^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL.replace("https://github.com", "https://www.github.com")})`
+      );
     }
   );
 
@@ -459,11 +456,11 @@ describe("Plugin tests", () => {
     expect(issue.state).toBe("open");
     // Verify the footnote is added after the line containing the markdown link
     expect(issue.body).toContain(
-      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_ [^01^]"
+      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_ [^deduplication-1^]"
     );
     // Verify the markdown link is not broken
     expect(issue.body).not.toContain(
-      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_[^01^]"
+      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_[^deduplication-1^]"
     );
   });
 
@@ -507,17 +504,12 @@ describe("Plugin tests", () => {
     }) as unknown as typeof octokit.rest.issues.listComments;
 
     context2.octokit.rest.issues.updateComment = mock(async (params: { owner: string; repo: string; comment_id: number; body: string }) => {
-      // Find the most similar sentence (first sentence in this case)
-      const updatedBody =
-        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^01^]`) +
-        `\n\n[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
-
       db.issueComments.update({
         where: {
           id: { equals: params.comment_id },
         },
         data: {
-          body: updatedBody,
+          body: params.body,
         },
       });
     }) as unknown as typeof octokit.rest.issues.updateComment;
@@ -525,7 +517,9 @@ describe("Plugin tests", () => {
     await runPlugin(context2);
 
     const updatedComment = db.issueComments.findFirst({ where: { id: { equals: 1 } } }) as unknown as Context<"issue_comment.created">["payload"]["comment"];
-    expect(updatedComment.body).toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    expect(updatedComment.body).toContain(
+      `[^annotation-issue-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL.replace("https://github.com", "https://www.github.com")})`
+    );
   });
 
   it("When demoFlag is true, it should skip storing issues in the database", async () => {
@@ -619,17 +613,12 @@ describe("Plugin tests", () => {
     }) as unknown as typeof octokit.rest.issues.getComment;
 
     context2.octokit.rest.issues.updateComment = mock(async (params: { owner: string; repo: string; comment_id: number; body: string }) => {
-      // Find the most similar sentence (first sentence in this case)
-      const updatedBody =
-        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^01^]`) +
-        `\n\n[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
-
       db.issueComments.update({
         where: {
           id: { equals: params.comment_id },
         },
         data: {
-          body: updatedBody,
+          body: params.body,
         },
       });
     }) as unknown as typeof octokit.rest.issues.updateComment;
@@ -637,7 +626,9 @@ describe("Plugin tests", () => {
     await runPlugin(context2);
 
     const updatedComment = db.issueComments.findFirst({ where: { id: { equals: 1 } } }) as unknown as Context<"issue_comment.created">["payload"]["comment"];
-    expect(updatedComment.body).not.toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    expect(updatedComment.body).not.toContain(
+      `[^annotation-issue-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL.replace("https://github.com", "https://www.github.com")})`
+    );
   });
 
   function createContext(

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import * as v from "valibot";
+import { urlSchema } from "../src/validators";
+
+describe("urlSchema", () => {
+  it("accepts user-copied GitHub issue and pull request URLs", () => {
+    expect(v.parse(urlSchema, "https://github.com/owner/repo/issues/123/")).toBe("https://github.com/owner/repo/issues/123/");
+    expect(v.parse(urlSchema, "https://www.github.com/owner/repo/pull/456?notification_referrer_id=abc#discussion_r1")).toBe(
+      "https://www.github.com/owner/repo/pull/456?notification_referrer_id=abc#discussion_r1"
+    );
+  });
+
+  it("rejects non-issue GitHub URLs", () => {
+    expect(() => v.parse(urlSchema, "https://github.com/owner/repo/tree/main")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes ubiquity-os-marketplace/text-vector-embeddings#92.

This addresses the March 2025 review adjustments from PR #91:

- relaxes GitHub issue/PR URL validation to accept common copied URLs with `www`, trailing slashes, queries, and fragments
- parses `/annotate` issue comment URLs more flexibly
- replaces zero-prefixed footnote IDs with semantic prefixes for deduplication and annotation footnotes
- keeps old numeric footnote cleanup compatible while removing new prefixed references correctly
- updates the `alwaysRecommend` config description for clearer LLM-facing wording
- adds `ms` for human-friendly embedding queue delay values while preserving numeric millisecond strings
- normalizes comment logger metadata naming and uses the logger throw pattern requested in review
- avoids fetching ordinary markdown links during image enrichment, preventing non-image links from hanging tests

## Verification

- `npx bun run build`
- `npx bun test`
- `npx prettier --check src/validators.ts src/utils/embedding-queue.ts src/types/plugin-input.ts src/utils/footnotes.ts src/handlers/issue-deduplication.ts src/handlers/annotate.ts src/handlers/user-annotate.ts src/adapters/supabase/helpers/comment.ts tests/main.test.ts tests/embedding-queue.test.ts tests/validators.test.ts package.json`

