### PR TITLE
Add private repository redaction switch

### DIFF
--- a/src/adapters/supabase/helpers/comment.ts
+++ b/src/adapters/supabase/helpers/comment.ts
@@ -49,6 +49,7 @@ export class Comment extends SuperSupabase {
 
   async createComment(commentData: CommentData, options: CommentWriteOptions = {}) {
     const { isPrivate } = commentData;
+    const shouldRedactPrivateContent = isPrivate && this.context.config.redactPrivateRepoComments;
     const { deferEmbedding: shouldDeferEmbedding = false } = options;
     const docType = commentData.docType ?? "issue_comment";
     const cleanedMarkdown = cleanMarkdown(commentData.markdown);
@@ -77,13 +78,13 @@ export class Comment extends SuperSupabase {
     }
     //Create the embedding for this comment
     let embedding: number[] | null = null;
-    if (!shouldDeferEmbedding && embeddingSource && !isPrivate) {
+    if (!shouldDeferEmbedding && embeddingSource && !shouldRedactPrivateContent) {
       embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
     }
     let finalMarkdown = shouldSkipEmbedding ? null : commentData.markdown;
     let finalPayload = commentData.payload;
 
-    if (isPrivate) {
+    if (shouldRedactPrivateContent) {
       finalMarkdown = null;
       finalPayload = null;
     }
@@ -110,6 +111,7 @@ export class Comment extends SuperSupabase {
 
   async updateComment(commentData: CommentData, options: CommentWriteOptions = {}) {
     const { isPrivate } = commentData;
+    const shouldRedactPrivateContent = isPrivate && this.context.config.redactPrivateRepoComments;
     const { deferEmbedding: shouldDeferEmbedding = false } = options;
     const docType = commentData.docType ?? "issue_comment";
     const cleanedMarkdown = cleanMarkdown(commentData.markdown);
@@ -119,13 +121,13 @@ export class Comment extends SuperSupabase {
     const embeddingSource = shouldSkipEmbedding ? null : cleanedMarkdown;
     //Create the embedding for this comment
     let embedding: number[] | null = null;
-    if (!shouldDeferEmbedding && embeddingSource && !isPrivate) {
+    if (!shouldDeferEmbedding && embeddingSource && !shouldRedactPrivateContent) {
       embedding = Array.from(await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource));
     }
     let finalMarkdown = shouldSkipEmbedding ? null : commentData.markdown;
     let finalPayload = commentData.payload;
 
-    if (isPrivate) {
+    if (shouldRedactPrivateContent) {
       finalMarkdown = null;
       finalPayload = null;
     }

--- a/src/adapters/supabase/helpers/comment.ts
+++ b/src/adapters/supabase/helpers/comment.ts
@@ -50,6 +50,7 @@ export class Comment extends SuperSupabase {
   async createComment(commentData: CommentData, options: CommentWriteOptions = {}) {
     const { isPrivate } = commentData;
     const shouldRedactPrivateContent = isPrivate && this.context.config.redactPrivateRepoComments;
+    const safeCommentData = shouldRedactPrivateContent ? { ...commentData, markdown: null, payload: null } : commentData;
     const { deferEmbedding: shouldDeferEmbedding = false } = options;
     const docType = commentData.docType ?? "issue_comment";
     const cleanedMarkdown = cleanMarkdown(commentData.markdown);
@@ -66,13 +67,13 @@ export class Comment extends SuperSupabase {
     if (existingError) {
       this.context.logger.error("Error creating comment", {
         Error: existingError,
-        commentData,
+        commentData: safeCommentData,
       });
       return;
     }
     if (existingData && existingData.length > 0) {
       this.context.logger.warn("Comment already exists", {
-        commentData: commentData,
+        commentData: safeCommentData,
       });
       return;
     }
@@ -102,7 +103,7 @@ export class Comment extends SuperSupabase {
     if (error) {
       this.context.logger.error("Failed to create comment in database", {
         Error: error,
-        commentData,
+        commentData: safeCommentData,
       });
       return;
     }
@@ -112,6 +113,7 @@ export class Comment extends SuperSupabase {
   async updateComment(commentData: CommentData, options: CommentWriteOptions = {}) {
     const { isPrivate } = commentData;
     const shouldRedactPrivateContent = isPrivate && this.context.config.redactPrivateRepoComments;
+    const safeCommentData = shouldRedactPrivateContent ? { ...commentData, markdown: null, payload: null } : commentData;
     const { deferEmbedding: shouldDeferEmbedding = false } = options;
     const docType = commentData.docType ?? "issue_comment";
     const cleanedMarkdown = cleanMarkdown(commentData.markdown);
@@ -152,7 +154,7 @@ export class Comment extends SuperSupabase {
         this.context.logger.error("Error updating comment", {
           Error: error,
           commentData: {
-            commentData,
+            commentData: safeCommentData,
             markdown: finalMarkdown,
             embedding,
             payload: finalPayload,
@@ -163,7 +165,7 @@ export class Comment extends SuperSupabase {
       }
       this.context.logger.ok("Comment updated successfully with id: " + commentData.id, {
         commentData: {
-          commentData,
+          commentData: safeCommentData,
           markdown: finalMarkdown,
           embedding,
           payload: finalPayload,

--- a/src/adapters/supabase/helpers/issues.ts
+++ b/src/adapters/supabase/helpers/issues.ts
@@ -63,6 +63,7 @@ export class Issue extends SuperSupabase {
 
   async createIssue(issueData: IssueData, options: IssueWriteOptions = {}) {
     const { isPrivate } = issueData;
+    const shouldRedactPrivateContent = isPrivate && this.context.config.redactPrivateRepoComments;
     const { deferEmbedding: shouldDeferEmbedding = false } = options;
     const docType = resolveIssueDocType(issueData.payload, issueData.docType);
     const cleanedMarkdown = cleanMarkdown(issueData.markdown);
@@ -90,13 +91,13 @@ export class Issue extends SuperSupabase {
 
     //Create the embedding for this issue
     let embedding: number[] | null = null;
-    if (!shouldDeferEmbedding && embeddingSource && !isPrivate) {
+    if (!shouldDeferEmbedding && embeddingSource && !shouldRedactPrivateContent) {
       embedding = await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource);
     }
     let finalMarkdown = isShortIssue ? null : issueData.markdown;
     let finalPayload = issueData.payload;
 
-    if (isPrivate) {
+    if (shouldRedactPrivateContent) {
       finalMarkdown = null;
       finalPayload = null;
     }
@@ -124,6 +125,7 @@ export class Issue extends SuperSupabase {
 
   async updateIssue(issueData: IssueData, options: IssueWriteOptions = {}) {
     const { isPrivate } = issueData;
+    const shouldRedactPrivateContent = isPrivate && this.context.config.redactPrivateRepoComments;
     const { deferEmbedding: shouldDeferEmbedding = false } = options;
     const docType = resolveIssueDocType(issueData.payload, issueData.docType);
     const cleanedMarkdown = cleanMarkdown(issueData.markdown);
@@ -131,13 +133,13 @@ export class Issue extends SuperSupabase {
     const embeddingSource = !isShortIssue ? cleanedMarkdown : null;
     //Create the embedding for this issue
     let embedding: number[] | null = null;
-    if (!shouldDeferEmbedding && embeddingSource && !isPrivate) {
+    if (!shouldDeferEmbedding && embeddingSource && !shouldRedactPrivateContent) {
       embedding = Array.from(await this.context.adapters.voyage.embedding.createEmbedding(embeddingSource));
     }
     let finalMarkdown = isShortIssue ? null : issueData.markdown;
     let finalPayload = issueData.payload;
 
-    if (isPrivate) {
+    if (shouldRedactPrivateContent) {
       finalMarkdown = null;
       finalPayload = null;
     }

--- a/src/adapters/supabase/helpers/issues.ts
+++ b/src/adapters/supabase/helpers/issues.ts
@@ -64,6 +64,7 @@ export class Issue extends SuperSupabase {
   async createIssue(issueData: IssueData, options: IssueWriteOptions = {}) {
     const { isPrivate } = issueData;
     const shouldRedactPrivateContent = isPrivate && this.context.config.redactPrivateRepoComments;
+    const safeIssueData = shouldRedactPrivateContent ? { ...issueData, markdown: null, payload: null } : issueData;
     const { deferEmbedding: shouldDeferEmbedding = false } = options;
     const docType = resolveIssueDocType(issueData.payload, issueData.docType);
     const cleanedMarkdown = cleanMarkdown(issueData.markdown);
@@ -78,13 +79,13 @@ export class Issue extends SuperSupabase {
     if (existingError) {
       this.context.logger.error("Error creating issue", {
         Error: existingError,
-        issueData,
+        issueData: safeIssueData,
       });
       return;
     }
     if (existingData && existingData.length > 0) {
       this.context.logger.warn("Issue already exists", {
-        issueData: issueData,
+        issueData: safeIssueData,
       });
       return;
     }
@@ -116,7 +117,7 @@ export class Issue extends SuperSupabase {
     if (error) {
       this.context.logger.error("Failed to create issue in database", {
         Error: error,
-        issueData,
+        issueData: safeIssueData,
       });
       return;
     }
@@ -126,6 +127,7 @@ export class Issue extends SuperSupabase {
   async updateIssue(issueData: IssueData, options: IssueWriteOptions = {}) {
     const { isPrivate } = issueData;
     const shouldRedactPrivateContent = isPrivate && this.context.config.redactPrivateRepoComments;
+    const safeIssueData = shouldRedactPrivateContent ? { ...issueData, markdown: null, payload: null } : issueData;
     const { deferEmbedding: shouldDeferEmbedding = false } = options;
     const docType = resolveIssueDocType(issueData.payload, issueData.docType);
     const cleanedMarkdown = cleanMarkdown(issueData.markdown);
@@ -147,7 +149,7 @@ export class Issue extends SuperSupabase {
     const issues = await this.getIssue(issueData.id);
     if (!issues || issues.length === 0) {
       this.context.logger.debug("Issue does not exist, creating a new one");
-      await this.createIssue({ ...issueData, markdown: finalMarkdown, payload: finalPayload, isPrivate }, { deferEmbedding: shouldDeferEmbedding });
+      await this.createIssue({ ...safeIssueData, markdown: finalMarkdown, payload: finalPayload, isPrivate }, { deferEmbedding: shouldDeferEmbedding });
       return;
     }
 
@@ -167,7 +169,7 @@ export class Issue extends SuperSupabase {
       this.context.logger.error("Error updating issue", {
         Error: error,
         issueData: {
-          id: issueData.id,
+          id: safeIssueData.id,
           markdown: finalMarkdown,
           embedding,
           payload: finalPayload,
@@ -179,7 +181,7 @@ export class Issue extends SuperSupabase {
 
     this.context.logger.ok("Issue updated successfully with id: " + issueData.id, {
       issueData: {
-        id: issueData.id,
+        id: safeIssueData.id,
         markdown: finalMarkdown,
         embedding,
         payload: finalPayload,

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -20,6 +20,10 @@ export const pluginSettingsSchema = T.Object(
       T.Number({ default: 0, description: "If set to a value greater than 0, the bot will always recommend contributors, regardless of the similarity score." })
     ),
     demoFlag: T.Boolean({ default: false, description: "When true, disables storing issues and comments in the database." }),
+    redactPrivateRepoComments: T.Boolean({
+      default: false,
+      description: "When true, redacts private repository markdown and payload before persistent storage.",
+    }),
   },
   { default: {} }
 );

--- a/tests/__mocks__/adapter.ts
+++ b/tests/__mocks__/adapter.ts
@@ -40,8 +40,7 @@ export function createMockAdapters(context: Context) {
           }
           const cleanedMarkdown = commentData.markdown ? stripHtmlComments(commentData.markdown).trim() : "";
           const shouldRedact = shouldRedactPrivateContent(commentData.isPrivate);
-          const embeddingSource = shouldRedact ? "" : cleanedMarkdown;
-          const embedding = await context.adapters.voyage.embedding.createEmbedding(embeddingSource);
+          const embedding = shouldRedact ? new Array(3072).fill(0) : await context.adapters.voyage.embedding.createEmbedding(cleanedMarkdown);
           commentMap.set(commentData.id, {
             id: commentData.id,
             author_id: commentData.author_id,
@@ -59,8 +58,7 @@ export function createMockAdapters(context: Context) {
           }
           const cleanedMarkdown = commentData.markdown ? stripHtmlComments(commentData.markdown).trim() : "";
           const shouldRedact = shouldRedactPrivateContent(commentData.isPrivate);
-          const embeddingSource = shouldRedact ? "" : cleanedMarkdown;
-          const embedding = await context.adapters.voyage.embedding.createEmbedding(embeddingSource);
+          const embedding = shouldRedact ? new Array(3072).fill(0) : await context.adapters.voyage.embedding.createEmbedding(cleanedMarkdown);
           commentMap.set(commentData.id, {
             id: commentData.id,
             author_id: commentData.author_id,

--- a/tests/__mocks__/adapter.ts
+++ b/tests/__mocks__/adapter.ts
@@ -8,6 +8,7 @@ import { stripHtmlComments } from "../../src/utils/markdown-comments";
 export interface CommentMock {
   id: string;
   author_id: number;
+  markdown: string | null;
   payload?: Record<string, unknown> | null;
   type?: string;
   issue_id?: string;
@@ -28,6 +29,8 @@ export function createMockAdapters(context: Context) {
   const issueMap: Map<string, IssueData> = new Map();
   const trackedIssues = new Set<string>();
 
+  const shouldRedactPrivateContent = (isPrivate?: boolean) => Boolean(isPrivate && context.config.redactPrivateRepoComments);
+
   return {
     supabase: {
       comment: {
@@ -36,12 +39,15 @@ export function createMockAdapters(context: Context) {
             throw new Error("Comment already exists");
           }
           const cleanedMarkdown = commentData.markdown ? stripHtmlComments(commentData.markdown).trim() : "";
-          const embeddingSource = commentData.isPrivate ? "" : cleanedMarkdown;
+          const shouldRedact = shouldRedactPrivateContent(commentData.isPrivate);
+          const embeddingSource = shouldRedact ? "" : cleanedMarkdown;
           const embedding = await context.adapters.voyage.embedding.createEmbedding(embeddingSource);
           commentMap.set(commentData.id, {
             id: commentData.id,
             author_id: commentData.author_id,
+            markdown: shouldRedact ? null : commentData.markdown,
             embedding,
+            payload: shouldRedact ? null : commentData.payload,
             issue_id: commentData.issue_id,
           });
           console.log("Comment created", commentData.id, commentMap.get(commentData.id));
@@ -52,13 +58,15 @@ export function createMockAdapters(context: Context) {
             throw new Error(STRINGS.COMMENT_DOES_NOT_EXIST);
           }
           const cleanedMarkdown = commentData.markdown ? stripHtmlComments(commentData.markdown).trim() : "";
-          const embeddingSource = commentData.isPrivate ? "" : cleanedMarkdown;
+          const shouldRedact = shouldRedactPrivateContent(commentData.isPrivate);
+          const embeddingSource = shouldRedact ? "" : cleanedMarkdown;
           const embedding = await context.adapters.voyage.embedding.createEmbedding(embeddingSource);
           commentMap.set(commentData.id, {
             id: commentData.id,
             author_id: commentData.author_id,
+            markdown: shouldRedact ? null : commentData.markdown,
             embedding,
-            payload: commentData.payload,
+            payload: shouldRedact ? null : commentData.payload,
             issue_id: commentData.issue_id,
           });
         }),
@@ -118,10 +126,20 @@ export function createMockAdapters(context: Context) {
           return [];
         }),
         createIssue: jest.fn(async (issue: IssueData) => {
-          issueMap.set(issue.id, issue);
+          const shouldRedact = shouldRedactPrivateContent(issue.isPrivate);
+          issueMap.set(issue.id, {
+            ...issue,
+            markdown: shouldRedact ? null : issue.markdown,
+            payload: shouldRedact ? null : issue.payload,
+          });
         }),
         updateIssue: jest.fn(async (issue: IssueData) => {
-          issueMap.set(issue.id, issue);
+          const shouldRedact = shouldRedactPrivateContent(issue.isPrivate);
+          issueMap.set(issue.id, {
+            ...issue,
+            markdown: shouldRedact ? null : issue.markdown,
+            payload: shouldRedact ? null : issue.payload,
+          });
         }),
       },
       fetchComments: jest.fn(async (issueId: string) => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -579,6 +579,48 @@ describe("Plugin tests", () => {
     expect(comment.embedding).toBeDefined();
   });
 
+  it("When private repository redaction is disabled by default, it should store private issue and comment content", async () => {
+    const { context: issueContext } = createContextIssues(DEFAULT_BODY, "privateIssue", 12, "Private Test Issue");
+    issueContext.payload.repository.private = true;
+
+    await runPlugin(issueContext);
+
+    const issue = (await issueContext.adapters.supabase.issue.getIssue("privateIssue")) as unknown as IssueMock;
+    expect(issue.markdown).toContain(DEFAULT_BODY);
+    expect(issue.payload).toBeDefined();
+
+    const { context: commentContext } = createContext(DEFAULT_BODY, 1, 1, 1, "privateComment", DEFAULT_ISSUE_ID);
+    commentContext.payload.repository.private = true;
+
+    await runPlugin(commentContext);
+
+    const comment = (await commentContext.adapters.supabase.comment.getComment("privateComment")) as unknown as CommentMock;
+    expect(comment.markdown).toContain(DEFAULT_BODY);
+    expect(comment.payload).toBeDefined();
+  });
+
+  it("When private repository redaction is enabled, it should redact private issue and comment content", async () => {
+    const { context: issueContext } = createContextIssues(DEFAULT_BODY, "redactedPrivateIssue", 13, "Redacted Private Test Issue");
+    issueContext.payload.repository.private = true;
+    issueContext.config.redactPrivateRepoComments = true;
+
+    await runPlugin(issueContext);
+
+    const issue = (await issueContext.adapters.supabase.issue.getIssue("redactedPrivateIssue")) as unknown as IssueMock;
+    expect(issue.markdown).toBeNull();
+    expect(issue.payload).toBeNull();
+
+    const { context: commentContext } = createContext(DEFAULT_BODY, 1, 1, 1, "redactedPrivateComment", DEFAULT_ISSUE_ID);
+    commentContext.payload.repository.private = true;
+    commentContext.config.redactPrivateRepoComments = true;
+
+    await runPlugin(commentContext);
+
+    const comment = (await commentContext.adapters.supabase.comment.getComment("redactedPrivateComment")) as unknown as CommentMock;
+    expect(comment.markdown).toBeNull();
+    expect(comment.payload).toBeNull();
+  });
+
   it("When a user uses annotate command with a specified comment and 'repo' scope and the comment doesn't have similarity above match threshold with any issue from the same repository, it shouldn't update comment body with footnotes", async () => {
     const [annotateIssue] = fetchSimilarIssues("annotate");
     const { context } = createContextIssues(annotateIssue.issue_body, "annotate", 9, annotateIssue.title);
@@ -702,6 +744,7 @@ describe("Plugin tests", () => {
         jobMatchingThreshold: 0.95,
         annotateThreshold: 0.65,
         demoFlag: false,
+        redactPrivateRepoComments: false,
       },
       command: null,
       adapters: {} as Context["adapters"],


### PR DESCRIPTION
## Summary
- Add `redactPrivateRepoComments` config, defaulting to disabled so private repository content is stored by default.
- Apply private markdown and payload redaction only when the option is enabled.
- Sanitize private issue/comment data before error and warning logs when redaction is enabled, so redacted content cannot leak through logging paths.
- Align the test mock with production behavior by skipping embedding generation for redacted private comments.

## Submission criteria
- Implements the boolean `redactPrivateRepoComments` switch requested in #23.
- Keeps the default behavior as full capture/storage unless the switch is enabled.
- Applies redaction only for private repository issue/comment content.
- Addresses CodeRabbit's actionable review comments about log leakage and mock embedding behavior.

## Tests
- `npm_config_cache=.npm-cache npx --yes bun@latest test` — 36 pass, 0 fail
- `npm_config_cache=.npm-cache npx --yes bun@1.2.19 run build`
- `./node_modules/.bin/prettier --check src/adapters/supabase/helpers/comment.ts src/adapters/supabase/helpers/issues.ts tests/__mocks__/adapter.ts tests/main.test.ts`

Resolves #23