### PR TITLE
fix: deduplicate issue matching comments

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -31,14 +31,75 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+type IssueMatchingCommentContext = Context<"issues.opened" | "issues.edited" | "issues.labeled">;
+
+const MATCHMAKING_COMMENT_START = ">The following contributors may be suitable for this task:";
+const MATCHMAKING_COMMENT_MARKER = `>[!NOTE]\n${MATCHMAKING_COMMENT_START}`;
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
 }
 
-export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
+function isMatchmakingComment(comment: IssueCommentSummary) {
+  return Boolean(comment.body?.includes(MATCHMAKING_COMMENT_MARKER));
+}
+
+function sortCommentsById(comments: IssueCommentSummary[]) {
+  return [...comments].sort((first, second) => first.id - second.id);
+}
+
+async function listMatchmakingComments(context: IssueMatchingCommentContext) {
+  const { octokit, payload } = context;
+  const listIssues = (await octokit.paginate(octokit.rest.issues.listComments, {
+    owner: payload.repository.owner.login,
+    repo: payload.repository.name,
+    issue_number: payload.issue.number,
+  })) as IssueCommentSummary[];
+
+  return sortCommentsById(listIssues.filter(isMatchmakingComment));
+}
+
+async function deleteMatchmakingComment(context: IssueMatchingCommentContext, comment: IssueCommentSummary) {
   const { logger, octokit, payload } = context;
-  const issue = payload.issue;
-  const commentStart = ">The following contributors may be suitable for this task:";
+  try {
+    await octokit.rest.issues.deleteComment({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      comment_id: comment.id,
+    });
+  } catch (error) {
+    logger.warn("Failed to delete duplicate matchmaking comment.", { commentId: comment.id, error: error instanceof Error ? error : new Error(String(error)) });
+  }
+}
+
+async function deleteMatchmakingComments(context: IssueMatchingCommentContext, comments: IssueCommentSummary[]) {
+  await Promise.all(comments.map((comment) => deleteMatchmakingComment(context, comment)));
+}
+
+async function reconcileMatchmakingComments(context: IssueMatchingCommentContext, body: string, preferredCommentId?: number) {
+  const { octokit, payload } = context;
+  const matchingComments = await listMatchmakingComments(context);
+  if (matchingComments.length === 0) {
+    return;
+  }
+
+  const keeper = matchingComments.find((comment) => comment.id === preferredCommentId) ?? matchingComments[0];
+  const duplicateComments = matchingComments.filter((comment) => comment.id !== keeper.id);
+
+  if (keeper.body !== body) {
+    await octokit.rest.issues.updateComment({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      comment_id: keeper.id,
+      body,
+    });
+  }
+
+  await deleteMatchmakingComments(context, duplicateComments);
+}
+
+export async function issueMatchingWithComment(context: IssueMatchingCommentContext) {
+  const { logger, octokit, payload } = context;
 
   const result = await issueMatching(context);
 
@@ -48,25 +109,11 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
 
   const { matchResultArray, sortedContributors } = result;
 
-  // Fetch if any previous comment exists
-  const listIssues = (await octokit.paginate(octokit.rest.issues.listComments, {
-    owner: payload.repository.owner.login,
-    repo: payload.repository.name,
-    issue_number: issue.number,
-  })) as IssueCommentSummary[];
-
-  //Check if the comment already exists
-  const existingComment = listIssues.find((comment) => comment.body && comment.body.includes(">[!NOTE]" + "\n" + commentStart));
+  const matchingComments = await listMatchmakingComments(context);
+  const existingComment = matchingComments[0];
 
   if (matchResultArray.size === 0) {
-    if (existingComment) {
-      // If the comment already exists, delete it
-      await octokit.rest.issues.deleteComment({
-        owner: payload.repository.owner.login,
-        repo: payload.repository.name,
-        comment_id: existingComment.id,
-      });
-    }
+    await deleteMatchmakingComments(context, matchingComments);
     logger.debug("No suitable contributors found");
     return;
   }
@@ -80,19 +127,21 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
   logger.debug("Comment to be added", { comment });
 
   if (existingComment) {
-    await context.octokit.rest.issues.updateComment({
+    await octokit.rest.issues.updateComment({
       owner: payload.repository.owner.login,
       repo: payload.repository.name,
       comment_id: existingComment.id,
       body: comment,
     });
+    await reconcileMatchmakingComments(context, comment, existingComment.id);
   } else {
-    await context.octokit.rest.issues.createComment({
+    await octokit.rest.issues.createComment({
       owner: payload.repository.owner.login,
       repo: payload.repository.name,
       issue_number: payload.issue.number,
       body: comment,
     });
+    await reconcileMatchmakingComments(context, comment);
   }
 }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -329,6 +329,59 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("98% Match");
   });
 
+  it("When issue matching creates concurrent duplicate comments, it keeps one matchmaking comment", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete", 3, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.createIssue = mock(async () => {
+      createIssue(
+        taskCompleteIssue.issue_body,
+        "task_complete",
+        taskCompleteIssue.title,
+        3,
+        { login: "test", id: 1 },
+        "open",
+        null,
+        STRINGS.TEST_REPO,
+        STRINGS.USER_1
+      );
+    });
+
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Similar Issue: Suggest based on Similarity",
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: "contributor1", url: "https://github.com/contributor1" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.paginate = mock(async () =>
+      db.issueComments.findMany({ where: { issue_number: { equals: 3 } } })
+    ) as unknown as typeof context.octokit.paginate;
+
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 10, "task_complete", params.issue_number);
+      createComment(params.body, 11, "task_complete_duplicate", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    context.octokit.rest.issues.deleteComment = mock(async (params: { owner: string; repo: string; comment_id: number }) => {
+      db.issueComments.delete({ where: { id: { equals: params.comment_id } } });
+    }) as unknown as typeof octokit.rest.issues.deleteComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { issue_number: { equals: 3 } } });
+    expect(comments.length).toBe(1);
+    expect(comments[0].id).toBe(10);
+    expect(comments[0].body).toContain(STRINGS.CONTRIBUTOR_SUGGESTION_TEXT);
+    expect(context.octokit.rest.issues.deleteComment).toHaveBeenCalledTimes(1);
+  });
+
   it("When issue matching is triggered with alwaysRecommend enabled, it should suggest contributors regardless of similarity", async () => {
     const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
     const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_always", 6, taskCompleteIssue.title);


### PR DESCRIPTION
## Summary
- keep a single issue-matching recommendation comment per issue
- clean up duplicate matchmaking comments after update/create races
- add a regression test for concurrent duplicate comment creation

Fixes #94

## Tests
- bun run build
- bun test