### PR TITLE
fix: dedupe matchmaking comments

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -31,14 +31,42 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+const MATCHMAKING_COMMENT_MARKER = "<!-- ubiquity-os-text-vector-embeddings:matchmaking -->";
+const MATCHMAKING_COMMENT_HEADER = ">[!NOTE]\n>The following contributors may be suitable for this task:";
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
 }
 
+function isMatchmakingComment(comment: IssueCommentSummary) {
+  return Boolean(comment.body?.includes(MATCHMAKING_COMMENT_MARKER) || comment.body?.includes(MATCHMAKING_COMMENT_HEADER));
+}
+
+async function listIssueComments(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">): Promise<IssueCommentSummary[]> {
+  const { octokit, payload } = context;
+  return (await octokit.paginate(octokit.rest.issues.listComments, {
+    owner: payload.repository.owner.login,
+    repo: payload.repository.name,
+    issue_number: payload.issue.number,
+  })) as IssueCommentSummary[];
+}
+
+async function deleteDuplicateMatchmakingComments(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">, comments: IssueCommentSummary[]) {
+  const { octokit, payload } = context;
+  const [, ...duplicates] = comments;
+  await Promise.all(
+    duplicates.map((comment) =>
+      octokit.rest.issues.deleteComment({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        comment_id: comment.id,
+      })
+    )
+  );
+}
+
 export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
   const { logger, octokit, payload } = context;
-  const issue = payload.issue;
-  const commentStart = ">The following contributors may be suitable for this task:";
 
   const result = await issueMatching(context);
 
@@ -48,15 +76,9 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
 
   const { matchResultArray, sortedContributors } = result;
 
-  // Fetch if any previous comment exists
-  const listIssues = (await octokit.paginate(octokit.rest.issues.listComments, {
-    owner: payload.repository.owner.login,
-    repo: payload.repository.name,
-    issue_number: issue.number,
-  })) as IssueCommentSummary[];
-
-  //Check if the comment already exists
-  const existingComment = listIssues.find((comment) => comment.body && comment.body.includes(">[!NOTE]" + "\n" + commentStart));
+  const existingComments = (await listIssueComments(context)).filter(isMatchmakingComment);
+  const existingComment = existingComments[0] ?? null;
+  await deleteDuplicateMatchmakingComments(context, existingComments);
 
   if (matchResultArray.size === 0) {
     if (existingComment) {
@@ -87,6 +109,20 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
       body: comment,
     });
   } else {
+    const latestExistingComments = (await listIssueComments(context)).filter(isMatchmakingComment);
+    const latestExistingComment = latestExistingComments[0] ?? null;
+    await deleteDuplicateMatchmakingComments(context, latestExistingComments);
+
+    if (latestExistingComment) {
+      await context.octokit.rest.issues.updateComment({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        comment_id: latestExistingComment.id,
+        body: comment,
+      });
+      return;
+    }
+
     await context.octokit.rest.issues.createComment({
       owner: payload.repository.owner.login,
       repo: payload.repository.name,
@@ -286,7 +322,7 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
  * @returns The comment to be added to the issue
  */
 function commentBuilder(matchResultArray: Map<string, Array<string>>): string {
-  const commentLines: string[] = [">[!NOTE]", ">The following contributors may be suitable for this task:"];
+  const commentLines: string[] = [MATCHMAKING_COMMENT_MARKER, ">[!NOTE]", ">The following contributors may be suitable for this task:"];
   matchResultArray.forEach((issues: Array<string>, assignee: string) => {
     commentLines.push(`>### [${assignee}](https://www.github.com/${assignee})`);
     issues.forEach((issue: string) => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -329,6 +329,62 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("98% Match");
   });
 
+  it("When issue matching finds existing matchmaking comments, it updates one and removes duplicates", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_dedupe", 7, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.createIssue = mock(async () => {
+      createIssue(
+        taskCompleteIssue.issue_body,
+        "task_complete_dedupe",
+        taskCompleteIssue.title,
+        7,
+        { login: "test", id: 1 },
+        "open",
+        null,
+        STRINGS.TEST_REPO,
+        STRINGS.USER_1
+      );
+    });
+
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Similar Issue: Suggest based on Similarity",
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: "contributor1", url: "https://github.com/contributor1" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.paginate = mock().mockResolvedValue([
+      { id: 10, body: `>[!NOTE]\n>${STRINGS.CONTRIBUTOR_SUGGESTION_TEXT}` },
+      { id: 11, body: `<!-- ubiquity-os-text-vector-embeddings:matchmaking -->\n>[!NOTE]\n>${STRINGS.CONTRIBUTOR_SUGGESTION_TEXT}` },
+    ]) as unknown as typeof context.octokit.paginate;
+
+    context.octokit.rest.issues.updateComment = mock(async () => {}) as unknown as typeof context.octokit.rest.issues.updateComment;
+    context.octokit.rest.issues.deleteComment = mock(async () => {}) as unknown as typeof context.octokit.rest.issues.deleteComment;
+    context.octokit.rest.issues.createComment = mock(async () => {}) as unknown as typeof context.octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    expect(context.octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comment_id: 10,
+        body: expect.stringContaining("contributor1"),
+      })
+    );
+    expect(context.octokit.rest.issues.deleteComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comment_id: 11,
+      })
+    );
+    expect(context.octokit.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+
   it("When issue matching is triggered with alwaysRecommend enabled, it should suggest contributors regardless of similarity", async () => {
     const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
     const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_always", 6, taskCompleteIssue.title);


### PR DESCRIPTION
Closes #94

## Summary

- Adds a stable hidden marker to matchmaking recommendation comments.
- Treats both the new marker and the legacy note header as existing matchmaking comments.
- Updates the existing matchmaking comment instead of creating another one.
- Deletes duplicate matchmaking comments when multiple webhook invocations already created them.
- Re-checks comments immediately before create to reduce duplicate posts when label events arrive close together.
- Adds a regression test covering duplicate cleanup and update behavior.

## Verification

- `npx @ubiquity-os/plugin-manifest-tool@latest`
- `npx tsc --noEmit`
- `npx prettier --check src/handlers/issue-matching.ts tests/main.test.ts`
- `npx eslint src/handlers/issue-matching.ts tests/main.test.ts`
- `git diff --check`

Note: `npm install` requires `--legacy-peer-deps` in this environment because of the existing valibot peer dependency conflict. `bun test` was not run because Bun is not installed in this container.