### PR TITLE
fix: address vector embedding review adjustments

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -4,6 +4,7 @@ import { processSimilarIssues, IssueGraphqlResponse, findMostSimilarSentence } f
 import { CommentSimilaritySearchResult } from "../adapters/supabase/helpers/comment";
 import { stripHtmlComments } from "../utils/markdown-comments";
 import { appendFootnoteRefsToFirstLine, insertFootnoteRefNearSentence } from "../utils/footnote-placement";
+import { createFootnoteRef, getHighestFootnoteIndex } from "../utils/footnote-id";
 
 interface CommentGraphqlResponse {
   node: {
@@ -144,9 +145,7 @@ async function handleSimilarIssuesAndComments(
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
-  const existingFootnotes = commentBody.match(footnoteRegex) || [];
-  let highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn.match(/\d+/)?.[0] ?? "0"))) : 0;
+  let highestFootnoteIndex = getHighestFootnoteIndex(commentBody, "annotation");
   let updatedBody = commentBody;
   const footnotes: string[] = [];
   const orphanRefs: string[] = [];
@@ -154,7 +153,7 @@ async function handleSimilarIssuesAndComments(
   issueList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   issueList.forEach((issue, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = createFootnoteRef("annotation", footnoteIndex);
     const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -184,7 +183,7 @@ async function handleSimilarIssuesAndComments(
   commentList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   commentList.forEach((comment, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = createFootnoteRef("annotation", footnoteIndex);
     const modifiedUrl = comment.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = comment.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -277,7 +276,7 @@ async function processSimilarComments(
  * @returns True if a annotate footnote exists, false otherwise
  */
 export function checkIfAnnotateFootNoteExists(content: string): boolean {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
+  const footnoteDefRegex = /\[\^(?:annotation-)?(\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
   const footnotes = content.match(footnoteDefRegex);
   return !!footnotes;
 }
@@ -289,13 +288,15 @@ export function checkIfAnnotateFootNoteExists(content: string): boolean {
  * @returns The content without footnotes
  */
 export function removeAnnotateFootnotes(content: string): string {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
+  const footnoteDefRegex = /\[\^(?:annotation-)?(\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
   const footnotes = content.match(footnoteDefRegex);
   let contentWithoutFootnotes = content.replace(footnoteDefRegex, "");
   if (footnotes) {
     footnotes.forEach((footnote) => {
-      const footnoteNumber = footnote.match(/\d+/)?.[0];
-      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${footnoteNumber}\\^\\]`, "g"), "");
+      const footnoteNumber = footnote.match(/\[\^(?:annotation-)?(\d+)\^\]/)?.[1];
+      contentWithoutFootnotes = contentWithoutFootnotes
+        .replace(new RegExp(`\\[\\^${footnoteNumber}\\^\\]`, "g"), "")
+        .replace(new RegExp(`\\[\\^annotation-${footnoteNumber}\\^\\]`, "g"), "");
     });
   }
   return contentWithoutFootnotes;

--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -5,6 +5,7 @@ import { IssueSimilaritySearchResult } from "../adapters/supabase/helpers/issues
 import { Context } from "../types/index";
 import { appendPluginUpdateComment, normalizeWhitespace, stripHtmlComments, stripPluginUpdateComments } from "../utils/markdown-comments";
 import { appendFootnoteRefsToFirstLine, insertFootnoteRefNearSentence } from "../utils/footnote-placement";
+import { createFootnoteRef, getHighestFootnoteIndex } from "../utils/footnote-id";
 import { stripDuplicateFootnotes } from "../utils/footnotes";
 import { findEditDistance } from "../utils/string-similarity";
 
@@ -194,9 +195,7 @@ async function handleSimilarIssuesComment(
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
-  const existingFootnotes = issueBody.match(footnoteRegex) || [];
-  const highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn.match(/\d+/)?.[0] ?? "0"))) : 0;
+  const highestFootnoteIndex = getHighestFootnoteIndex(issueBody, "deduplication");
   let updatedBody = issueBody;
   const footnotes: string[] = [];
   const orphanRefs: string[] = [];
@@ -204,7 +203,7 @@ async function handleSimilarIssuesComment(
   relevantIssues.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   relevantIssues.forEach((issue, index) => {
     const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = createFootnoteRef("deduplication", footnoteIndex);
     const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -401,7 +400,7 @@ export async function cleanContent(context: Context, content: string): Promise<s
  * @returns True if a duplicate footnote exists, false otherwise
  */
 export function checkIfDuplicateFootNoteExists(content: string): boolean {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
+  const footnoteDefRegex = /\[\^(?:deduplication-)?(\d+)\^\]: .*?\d+% possible duplicate - [^\n]+(\n|$)/g;
   const footnotes = content.match(footnoteDefRegex);
   return !!footnotes;
 }

--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -46,8 +46,6 @@ async function postCommandResponse(context: Context<"issue_comment.created">, bo
 }
 
 export async function commandHandler(context: Context<"issue_comment.created">) {
-  const { logger } = context;
-
   if (!context.command) {
     return;
   }
@@ -60,7 +58,7 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
       const commentRegex = /#issuecomment-(\d+)$/;
       const match = commentUrl.match(commentRegex);
       if (!match) {
-        throw logger.error("Invalid comment URL");
+        throw context.logger.info("Invalid comment URL");
       }
       commentId = match[1];
     }
@@ -69,7 +67,6 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
 }
 
 export async function userAnnotate(context: Context<"issue_comment.created">) {
-  const { logger } = context;
   const comment = context.payload.comment;
   const splitComment = comment.body.trim().split(/\s+/);
   const commandName = splitComment[0].replace("/", "");
@@ -84,17 +81,17 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
         scope = splitComment[2];
 
         if (scope !== "global" && scope !== "org" && scope !== "repo") {
-          throw logger.error("Invalid scope");
+          throw context.logger.info("Invalid scope");
         }
 
         const commentRegex = /#issuecomment-(\d+)$/;
         const match = commentUrl.match(commentRegex);
         if (!match) {
-          throw logger.error("Invalid comment URL");
+          throw context.logger.info("Invalid comment URL");
         }
         commentId = match[1];
       } else {
-        throw logger.error("Invalid parameters");
+        throw context.logger.info("Invalid parameters");
       }
     }
     await annotate(context, commentId, scope);

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -17,7 +17,10 @@ export const pluginSettingsSchema = T.Object(
     }),
     jobMatchingThreshold: T.Number({ default: 0.75, description: "The minimum similarity score when considering users to be suitable for a job." }),
     alwaysRecommend: T.Optional(
-      T.Number({ default: 0, description: "If set to a value greater than 0, the bot will always recommend contributors, regardless of the similarity score." })
+      T.Number({
+        default: 0,
+        description: "This amount of contributors will always be recommended regardless of the similarity score.",
+      })
     ),
     demoFlag: T.Boolean({ default: false, description: "When true, disables storing issues and comments in the database." }),
   },

--- a/src/utils/embedding-queue.ts
+++ b/src/utils/embedding-queue.ts
@@ -10,7 +10,7 @@ export type EmbeddingQueueSettings = {
 
 const isQueueEnabledByDefault = true;
 const DEFAULT_BATCH_SIZE = 50;
-const DEFAULT_DELAY_MS = 1000;
+const DEFAULT_DELAY_MS = 1_000;
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_CONCURRENCY = 1;
 

--- a/src/utils/footnote-id.ts
+++ b/src/utils/footnote-id.ts
@@ -1,0 +1,21 @@
+const FOOTNOTE_ID_REGEX = /\[\^([A-Za-z][A-Za-z0-9-]*-)?(\d+)\^\]/g;
+
+export function createFootnoteId(prefix: string, index: number): string {
+  return `${prefix}-${index.toString().padStart(2, "0")}`;
+}
+
+export function createFootnoteRef(prefix: string, index: number): string {
+  return `[^${createFootnoteId(prefix, index)}^]`;
+}
+
+export function getHighestFootnoteIndex(content: string, prefix?: string): number {
+  let highestIndex = 0;
+  for (const match of content.matchAll(FOOTNOTE_ID_REGEX)) {
+    const [, foundPrefix, rawIndex] = match;
+    if (prefix && foundPrefix && foundPrefix !== `${prefix}-`) {
+      continue;
+    }
+    highestIndex = Math.max(highestIndex, Number.parseInt(rawIndex, 10));
+  }
+  return highestIndex;
+}

--- a/src/utils/footnotes.ts
+++ b/src/utils/footnotes.ts
@@ -1,4 +1,4 @@
-const FOOTNOTE_DEF_REGEX = /\[\^(\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
+const FOOTNOTE_DEF_REGEX = /\[\^(?:deduplication-)?(\d+)\^\]: .*?\d+% possible duplicate - [^\n]+(\n|$)/g;
 
 export function removeCautionMessages(content: string): string {
   const cautionRegex = />[!CAUTION]\n> This issue may be a duplicate of the following issues:\n((> - \[[^\]]+\]\([^)]+\)\n)+)/g;
@@ -10,11 +10,13 @@ export function stripDuplicateFootnotes(content: string): string {
   let contentWithoutFootnotes = content.replace(FOOTNOTE_DEF_REGEX, "");
   if (footnotes) {
     footnotes.forEach((footnote) => {
-      const footnoteNumber = footnote.match(/\d+/)?.[0];
+      const footnoteNumber = footnote.match(/\[\^(?:deduplication-)?(\d+)\^\]/)?.[1];
       if (!footnoteNumber) {
         return;
       }
-      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${footnoteNumber}\\^\\]`, "g"), "");
+      contentWithoutFootnotes = contentWithoutFootnotes
+        .replace(new RegExp(`\\[\\^${footnoteNumber}\\^\\]`, "g"), "")
+        .replace(new RegExp(`\\[\\^deduplication-${footnoteNumber}\\^\\]`, "g"), "");
     });
   }
   return removeCautionMessages(contentWithoutFootnotes);

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,6 +1,12 @@
 import * as v from "valibot";
 
-export const urlSchema = v.pipe(v.string(), v.url(), v.regex(/https:\/\/github\.com\/[^/]+\/[^/]+\/(issues|pull)\/\d+$/));
+const GITHUB_ISSUE_OR_PULL_URL_REGEX = /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/(issues|pull)\/\d+\/?$/;
+
+export const urlSchema = v.pipe(
+  v.string(),
+  v.url("Expected a valid URL."),
+  v.regex(GITHUB_ISSUE_OR_PULL_URL_REGEX, "Expected a GitHub issue or pull request URL, e.g. https://github.com/owner/repo/issues/123.")
+);
 
 export const querySchema = v.object({
   issueUrls: v.union([v.array(urlSchema), urlSchema]),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,6 +24,7 @@ import { PluginSettings, pluginSettingsSchema } from "./types/plugin-input";
 import { querySchema, responseSchema } from "./validators";
 
 const pluginManifest = manifest as Manifest & { homepage_url?: string };
+const RATE_LIMIT_WINDOW_MS = 60_000;
 
 function buildRuntimeManifest(request: Request) {
   return {
@@ -66,7 +67,7 @@ export default {
     honoApp.use(cors());
     honoApp.use(
       rateLimiter({
-        windowMs: 60 * 1000,
+        windowMs: RATE_LIMIT_WINDOW_MS,
         limit: 100,
         standardHeaders: "draft-7",
         keyGenerator: (c) => {


### PR DESCRIPTION
Resolves #92

## Summary
- make GitHub URL validation messages more actionable
- switch deduplication and annotation footnotes to semantic prefixes while keeping legacy cleanup support
- use the logger.info throw pattern for user-facing command validation errors
- clarify the alwaysRecommend configuration description and name timing constants

## Validation
- bun run build
- bun test tests\embedding-queue.test.ts tests\review-comment-markdown.test.ts tests\postgres-issue-store.test.ts tests\postgres-rate-limit-store.test.ts

Note: full bun test is blocked locally on Windows by Bun 1.3.12 failing to resolve Octokit's toad-cache dependency, while Node can import it successfully.