### PR TITLE
Prioritize repository contributors in issue matching

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -1,6 +1,11 @@
 import { IssueSimilaritySearchResult } from "../adapters/supabase/helpers/issues";
 import { Context } from "../types/index";
 
+const LOW_CONFIDENCE_RECOMMENDATION_THRESHOLD = 25;
+const SAME_REPOSITORY_WEIGHT = 1;
+const SAME_ORGANIZATION_WEIGHT = 0.75;
+const GLOBAL_REPOSITORY_WEIGHT = 0.5;
+
 export interface IssueGraphqlResponse {
   node: {
     title: string;
@@ -22,6 +27,7 @@ export interface IssueGraphqlResponse {
     };
   };
   similarity: number;
+  adjustedSimilarity: number;
 }
 
 type IssueNodeResponse = IssueGraphqlResponse | { node: null };
@@ -31,8 +37,91 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+type SortedContributor = {
+  login: string;
+  matches: string[];
+  maxSimilarity: number;
+};
+
+type CodeContributor = {
+  login?: string | null;
+  contributions?: number;
+};
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
+}
+
+function getRepositoryWeight(context: Context<IssueMatchingEvents>, issue: IssueGraphqlResponse) {
+  const currentOwner = context.payload.repository.owner.login;
+  const currentRepo = context.payload.repository.name;
+  const matchedOwner = issue.node.repository.owner.login;
+  const matchedRepo = issue.node.repository.name;
+
+  if (matchedOwner === currentOwner && matchedRepo === currentRepo) {
+    return SAME_REPOSITORY_WEIGHT;
+  }
+
+  if (matchedOwner === currentOwner) {
+    return SAME_ORGANIZATION_WEIGHT;
+  }
+
+  return GLOBAL_REPOSITORY_WEIGHT;
+}
+
+function getSortedContributors(matchResultArray: Map<string, string[]>): SortedContributor[] {
+  return Array.from(matchResultArray.entries())
+    .map(([login, matches]) => ({
+      login,
+      matches,
+      maxSimilarity: matches.length ? Math.max(...matches.map((match) => parseInt(match.match(/`(\d+)% Match`/)?.[1] || "0"))) : 0,
+    }))
+    .sort((a, b) => b.maxSimilarity - a.maxSimilarity);
+}
+
+async function fetchRepositoryCodeContributors(context: Context<IssueMatchingEvents>, allowedLogins?: Set<string>): Promise<SortedContributor[]> {
+  try {
+    const { data: contributors } = await context.octokit.rest.repos.listContributors({
+      owner: context.payload.repository.owner.login,
+      repo: context.payload.repository.name,
+      per_page: 100,
+    });
+
+    return (contributors as CodeContributor[])
+      .filter((contributor) => contributor.login && (!allowedLogins || allowedLogins.has(contributor.login)))
+      .map((contributor) => {
+        const contributions = contributor.contributions ?? 0;
+        return {
+          login: contributor.login as string,
+          matches: [
+            `> Repository contributor fallback for [${context.payload.repository.owner.login}/${context.payload.repository.name}](https://www.github.com/${context.payload.repository.owner.login}/${context.payload.repository.name}) (${contributions} commits)`,
+          ],
+          maxSimilarity: 0,
+        };
+      });
+  } catch (error) {
+    context.logger.error(`Failed to fetch repository contributors: ${error}`);
+    return [];
+  }
+}
+
+function addContributorMatch(matchResultArray: Map<string, string[]>, login: string, match: string) {
+  if (matchResultArray.has(login)) {
+    matchResultArray.get(login)?.push(match);
+  } else {
+    matchResultArray.set(login, [match]);
+  }
+}
+
+function ensureContributors(matchResultArray: Map<string, string[]>, logins?: string[]) {
+  if (!logins) {
+    return;
+  }
+  for (const login of logins) {
+    if (!matchResultArray.has(login)) {
+      matchResultArray.set(login, []);
+    }
+  }
 }
 
 export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
@@ -195,6 +284,7 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
           return null;
         }
         issueObject.similarity = issue.similarity;
+        issueObject.adjustedSimilarity = issue.similarity * getRepositoryWeight(context, issueObject);
         return issueObject;
       } catch (error) {
         context.logger.error(`Failed to fetch issue ${issue.issue_id}: ${error}`, { issue });
@@ -219,59 +309,40 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
           if (options.allowedLogins && !options.allowedLogins.has(assignee.login)) {
             return;
           }
-          const similarityPercentage = Math.round(issue.similarity * 100);
+          const similarityPercentage = Math.round(issue.adjustedSimilarity * 100);
           const issueLink = issue.node.url.replace(/https?:\/\/github.com/, "https://www.github.com");
-          if (matchResultArray.has(assignee.login)) {
-            matchResultArray
-              .get(assignee.login)
-              ?.push(
-                `> \`${similarityPercentage}% Match\` [${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}](${issueLink})`
-              );
-          } else {
-            matchResultArray.set(assignee.login, [
-              `> \`${similarityPercentage}% Match\` [${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}](${issueLink})`,
-            ]);
-          }
+          addContributorMatch(
+            matchResultArray,
+            assignee.login,
+            `> \`${similarityPercentage}% Match\` [${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}](${issueLink})`
+          );
         });
       }
     });
 
-    if (options.ensureLogins) {
-      for (const login of options.ensureLogins) {
-        if (!matchResultArray.has(login)) {
-          matchResultArray.set(login, []);
-        }
+    ensureContributors(matchResultArray, options.ensureLogins);
+
+    let sortedContributors = getSortedContributors(matchResultArray);
+    const hasConfidentIssueMatch = sortedContributors.some((contributor) => contributor.maxSimilarity >= LOW_CONFIDENCE_RECOMMENDATION_THRESHOLD);
+    if (!hasConfidentIssueMatch) {
+      const codeContributors = await fetchRepositoryCodeContributors(context, options.allowedLogins);
+      matchResultArray.clear();
+      for (const contributor of codeContributors) {
+        matchResultArray.set(contributor.login, contributor.matches);
       }
+      ensureContributors(matchResultArray, options.ensureLogins);
+      sortedContributors = getSortedContributors(matchResultArray);
     }
 
     logger.debug("Matched issues", { matchResultArray, length: matchResultArray.size });
-
-    // Convert Map to array and sort by highest similarity
-    const sortedContributors = Array.from(matchResultArray.entries())
-      .map(([login, matches]) => ({
-        login,
-        matches,
-        maxSimilarity: matches.length ? Math.max(...matches.map((match) => parseInt(match.match(/`(\d+)% Match`/)?.[1] || "0"))) : 0,
-      }))
-      .sort((a, b) => b.maxSimilarity - a.maxSimilarity);
 
     logger.debug("Sorted contributors", { sortedContributors });
     return { matchResultArray, similarIssues, sortedContributors };
   }
 
   if (options.ensureLogins && options.ensureLogins.length > 0) {
-    for (const login of options.ensureLogins) {
-      if (!matchResultArray.has(login)) {
-        matchResultArray.set(login, []);
-      }
-    }
-    const sortedContributors = Array.from(matchResultArray.entries())
-      .map(([login, matches]) => ({
-        login,
-        matches,
-        maxSimilarity: 0,
-      }))
-      .sort((a, b) => b.maxSimilarity - a.maxSimilarity);
+    ensureContributors(matchResultArray, options.ensureLogins);
+    const sortedContributors = getSortedContributors(matchResultArray);
     return { matchResultArray, similarIssues: [], sortedContributors };
   }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6,6 +6,7 @@ import { Logs } from "@ubiquity-os/ubiquity-os-logger";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import dotenv from "dotenv";
 import { IssueSimilaritySearchResult } from "../src/adapters/supabase/helpers/issues";
+import { IssueGraphqlResponse } from "../src/handlers/issue-matching";
 import { Context } from "../src/types/context";
 import { Env } from "../src/types/index";
 import { CommentMock, createMockAdapters, IssueMock } from "./__mocks__/adapter";
@@ -379,6 +380,111 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain(STRINGS.CONTRIBUTOR_SUGGESTION_TEXT);
     expect(comments[0].body).toContain("contributor3");
     expect(comments[0].body).toContain("50% Match");
+  });
+
+  it("When issue matching spans repo, org, and global contexts, it should rank by adjusted similarity", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "weighted_match", 12, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { issue_id: "same-repo", similarity: 0.6 },
+      { issue_id: "same-org", similarity: 0.7 },
+      { issue_id: "global", similarity: 0.9 },
+    ] as IssueSimilaritySearchResult[]);
+    const globalContributor = "global-contributor";
+    const sameOrgContributor = "same-org-contributor";
+
+    context.octokit.graphql = mock(async (query: string, variables: { issueNodeId: string }) => {
+      expect(query).toContain("query ($issueNodeId: ID!)");
+      const issues = {
+        "same-repo": {
+          title: "Same repo issue",
+          url: "https://github.com/ubiquity/test-repo/issues/10",
+          state: "closed",
+          stateReason: "COMPLETED",
+          closed: true,
+          repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+          assignees: { nodes: [{ login: "same-repo-contributor", url: "https://github.com/same-repo-contributor" }] },
+        },
+        "same-org": {
+          title: "Same org issue",
+          url: "https://github.com/ubiquity/another-repo/issues/20",
+          state: "closed",
+          stateReason: "COMPLETED",
+          closed: true,
+          repository: { owner: { login: STRINGS.USER_1 }, name: "another-repo" },
+          assignees: { nodes: [{ login: sameOrgContributor, url: `https://github.com/${sameOrgContributor}` }] },
+        },
+        global: {
+          title: "Global issue",
+          url: "https://github.com/other-org/other-repo/issues/30",
+          state: "closed",
+          stateReason: "COMPLETED",
+          closed: true,
+          repository: { owner: { login: "other-org" }, name: "other-repo" },
+          assignees: { nodes: [{ login: globalContributor, url: `https://github.com/${globalContributor}` }] },
+        },
+      } satisfies Record<string, IssueGraphqlResponse["node"]>;
+
+      return { node: issues[variables.issueNodeId] };
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 4, "weighted_match", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "weighted_match" } } });
+    expect(comments.length).toBe(1);
+    expect(comments[0].body).toContain("60% Match");
+    expect(comments[0].body).toContain("52% Match");
+    expect(comments[0].body).toContain("45% Match");
+    expect(comments[0].body.indexOf("same-repo-contributor")).toBeLessThan(comments[0].body.indexOf(sameOrgContributor));
+    expect(comments[0].body.indexOf(sameOrgContributor)).toBeLessThan(comments[0].body.indexOf(globalContributor));
+  });
+
+  it("When all issue matches are below the low confidence threshold, it should recommend repository code contributors", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "low_confidence_match", 13, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { issue_id: "low-score", similarity: 0.2 },
+    ] as IssueSimilaritySearchResult[]);
+
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Low score issue",
+        url: "https://github.com/other-org/other-repo/issues/40",
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: "other-org" }, name: "other-repo" },
+        assignees: { nodes: [{ login: "low-score-contributor", url: "https://github.com/low-score-contributor" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.rest.repos.listContributors = mock(async () => ({
+      data: [
+        { login: "top-code-contributor", contributions: 42 },
+        { login: "second-code-contributor", contributions: 15 },
+      ],
+    })) as unknown as typeof context.octokit.rest.repos.listContributors;
+
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 5, "low_confidence_match", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "low_confidence_match" } } });
+    expect(comments.length).toBe(1);
+    expect(comments[0].body).toContain("top-code-contributor");
+    expect(comments[0].body).toContain("Repository contributor fallback");
+    expect(comments[0].body).toContain("42 commits");
+    expect(comments[0].body).not.toContain("low-score-contributor");
   });
 
   it("When an issue contains markdown links, footnotes should be added after the entire line", async () => {


### PR DESCRIPTION
## Summary
- Applies repository-aware weighting to issue recommendation matches:
  - same repository: full score
  - same organization: 75%
  - global history: 50%
- Falls back to repository code contributors when all adjusted matches are below 25%.
- Adds regression coverage for weighted ordering and fallback contributor recommendations.

Fixes #55

## Test Plan
- corepack pnpm exec eslint src/handlers/issue-matching.ts tests/main.test.ts --max-warnings=0
- corepack pnpm exec prettier --check src/handlers/issue-matching.ts tests/main.test.ts
- corepack pnpm dlx @ubiquity-os/plugin-manifest-tool@latest
- corepack pnpm exec tsc -p tsconfig.json --noEmit --pretty false
- npm_config_registry=https://registry.npmjs.org corepack pnpm dlx bun@1.3.14 test tests/main.test.ts
