### PR TITLE
fix: update matchmaking placeholder comment

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -31,6 +31,9 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+const COMMENT_START = ">The following contributors may be suitable for this task:";
+const PLACEHOLDER_COMMENT = `>[!NOTE]\n${COMMENT_START}\n>_Searching for matches..._`;
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
 }
@@ -38,15 +41,6 @@ function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResp
 export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
   const { logger, octokit, payload } = context;
   const issue = payload.issue;
-  const commentStart = ">The following contributors may be suitable for this task:";
-
-  const result = await issueMatching(context);
-
-  if (!result) {
-    return;
-  }
-
-  const { matchResultArray, sortedContributors } = result;
 
   // Fetch if any previous comment exists
   const listIssues = (await octokit.paginate(octokit.rest.issues.listComments, {
@@ -56,7 +50,32 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
   })) as IssueCommentSummary[];
 
   //Check if the comment already exists
-  const existingComment = listIssues.find((comment) => comment.body && comment.body.includes(">[!NOTE]" + "\n" + commentStart));
+  let existingComment = listIssues.find((comment) => comment.body && comment.body.includes(">[!NOTE]" + "\n" + COMMENT_START));
+
+  if (!existingComment && context.eventName === "issues.opened") {
+    const createdComment = await context.octokit.rest.issues.createComment({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      issue_number: payload.issue.number,
+      body: PLACEHOLDER_COMMENT,
+    });
+    existingComment = createdComment.data;
+  }
+
+  const result = await issueMatching(context);
+
+  if (!result) {
+    if (existingComment && context.eventName === "issues.opened") {
+      await octokit.rest.issues.deleteComment({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        comment_id: existingComment.id,
+      });
+    }
+    return;
+  }
+
+  const { matchResultArray, sortedContributors } = result;
 
   if (matchResultArray.size === 0) {
     if (existingComment) {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -329,6 +329,48 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("98% Match");
   });
 
+  it("When issue matching runs on issue open, it creates a placeholder and updates it with matches", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_open", 5, taskCompleteIssue.title);
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([{ issue_id: "similar-open", similarity: 0.98 }]);
+
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Similar Issue: Suggest based on Similarity",
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: "contributor1", url: "https://github.com/contributor1" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 1, "task_complete_open", params.issue_number);
+      return { data: { id: 1, body: params.body } };
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    context.octokit.rest.issues.updateComment = mock(async (params: { owner: string; repo: string; comment_id: number; body: string }) => {
+      const comment = db.issueComments.findFirst({ where: { id: { equals: params.comment_id } } });
+      if (comment) {
+        comment.body = params.body;
+      }
+      return { data: comment };
+    }) as unknown as typeof octokit.rest.issues.updateComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "task_complete_open" } } });
+    expect(context.octokit.rest.issues.createComment).toHaveBeenCalledTimes(1);
+    expect(context.octokit.rest.issues.updateComment).toHaveBeenCalledTimes(1);
+    expect(comments.length).toBe(1);
+    expect(comments[0].body).toContain(STRINGS.CONTRIBUTOR_SUGGESTION_TEXT);
+    expect(comments[0].body).toContain("contributor1");
+    expect(comments[0].body).toContain("98% Match");
+  });
+
   it("When issue matching is triggered with alwaysRecommend enabled, it should suggest contributors regardless of similarity", async () => {
     const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
     const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_always", 6, taskCompleteIssue.title);


### PR DESCRIPTION
Resolves #94

## Summary

- Create a placeholder matchmaking comment during `issues.opened` before the similarity lookup runs.
- Reuse that placeholder via `updateComment` once matches are computed, so later label-triggered invocations edit the existing matchmaking comment instead of creating another one.
- Delete the placeholder if no matching result is produced on issue open.
- Added a regression test that verifies issue-open matching creates one placeholder and updates it into the final recommendation comment.

## Testing

- `npx prettier --check src\handlers\issue-matching.ts tests\main.test.ts`
- `npx eslint src\handlers\issue-matching.ts tests\main.test.ts`

Note: full `npx tsc --noEmit` is blocked locally because `manifest.json` is generated by the Bun prepare step, and Bun is not installed in this environment. The repo test runner is `bun test`, so I could not run the Bun test suite here.