### PR TITLE
Improve issue recommendation weighting and fallback

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -31,8 +31,85 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+type RepositoryInfo = {
+  owner: string;
+  repo: string;
+};
+
+type SortedContributor = {
+  login: string;
+  matches: string[];
+  maxSimilarity: number;
+};
+
+type RepositoryContributor = {
+  login?: string | null;
+  type?: string | null;
+  html_url?: string | null;
+  contributions?: number;
+};
+
+const MINIMUM_CONFIDENT_MATCH_PERCENTAGE = 25;
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
+}
+
+function getCurrentRepository(context: Context<IssueMatchingEvents>): RepositoryInfo | null {
+  if (context.payload.repository) {
+    return {
+      owner: context.payload.repository.owner.login,
+      repo: context.payload.repository.name,
+    };
+  }
+
+  const repositoryUrl = (context.payload.issue as { repository_url?: string }).repository_url;
+  const match = repositoryUrl?.match(/\/repos\/([^/]+)\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    owner: match[1],
+    repo: match[2],
+  };
+}
+
+function getContextWeight(currentRepository: RepositoryInfo | null, issue: IssueGraphqlResponse) {
+  if (!currentRepository) {
+    return 0.5;
+  }
+  const matchedOwner = issue.node.repository.owner.login;
+  const matchedRepo = issue.node.repository.name;
+  if (matchedOwner === currentRepository.owner && matchedRepo === currentRepository.repo) {
+    return 1;
+  }
+  if (matchedOwner === currentRepository.owner) {
+    return 0.75;
+  }
+  return 0.5;
+}
+
+function sortContributors(matchResultArray: Map<string, Array<string>>, commitCounts: Map<string, number> = new Map()): SortedContributor[] {
+  return Array.from(matchResultArray.entries())
+    .map(([login, matches]) => ({
+      login,
+      matches,
+      maxSimilarity: matches.length ? Math.max(...matches.map((match) => parseInt(match.match(/`(\d+)% Match`/)?.[1] || "0"))) : 0,
+    }))
+    .sort((a, b) => b.maxSimilarity - a.maxSimilarity || (commitCounts.get(b.login) || 0) - (commitCounts.get(a.login) || 0) || a.login.localeCompare(b.login));
+}
+
+function needsContributorFallback(sortedContributors: SortedContributor[]) {
+  return sortedContributors.length === 0 || sortedContributors[0].maxSimilarity <= MINIMUM_CONFIDENT_MATCH_PERCENTAGE;
+}
+
+function isUsableContributor(contributor: RepositoryContributor, issueAuthor?: string) {
+  const login = contributor.login;
+  if (!login || login === issueAuthor) {
+    return false;
+  }
+  return contributor.type !== "Bot" && !login.endsWith("[bot]");
 }
 
 export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
@@ -133,6 +210,7 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
     payload,
   } = context;
   const issue = payload.issue;
+  const currentRepository = getCurrentRepository(context);
   const authorType = issue.user?.type;
   const isHumanAuthor = authorType === "User";
   if (!isHumanAuthor) {
@@ -219,7 +297,7 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
           if (options.allowedLogins && !options.allowedLogins.has(assignee.login)) {
             return;
           }
-          const similarityPercentage = Math.round(issue.similarity * 100);
+          const similarityPercentage = Math.round(issue.similarity * getContextWeight(currentRepository, issue) * 100);
           const issueLink = issue.node.url.replace(/https?:\/\/github.com/, "https://www.github.com");
           if (matchResultArray.has(assignee.login)) {
             matchResultArray
@@ -246,14 +324,15 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
 
     logger.debug("Matched issues", { matchResultArray, length: matchResultArray.size });
 
-    // Convert Map to array and sort by highest similarity
-    const sortedContributors = Array.from(matchResultArray.entries())
-      .map(([login, matches]) => ({
-        login,
-        matches,
-        maxSimilarity: matches.length ? Math.max(...matches.map((match) => parseInt(match.match(/`(\d+)% Match`/)?.[1] || "0"))) : 0,
-      }))
-      .sort((a, b) => b.maxSimilarity - a.maxSimilarity);
+    let sortedContributors = sortContributors(matchResultArray);
+    if (!options.ensureLogins && needsContributorFallback(sortedContributors)) {
+      const fallback = await getRepositoryContributorFallback(context, currentRepository);
+      if (fallback) {
+        sortedContributors = fallback.sortedContributors;
+        logger.debug("Using repository contributor fallback", { sortedContributors });
+        return { matchResultArray: fallback.matchResultArray, similarIssues, sortedContributors };
+      }
+    }
 
     logger.debug("Sorted contributors", { sortedContributors });
     return { matchResultArray, similarIssues, sortedContributors };
@@ -265,19 +344,61 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
         matchResultArray.set(login, []);
       }
     }
-    const sortedContributors = Array.from(matchResultArray.entries())
-      .map(([login, matches]) => ({
-        login,
-        matches,
-        maxSimilarity: 0,
-      }))
-      .sort((a, b) => b.maxSimilarity - a.maxSimilarity);
+    const sortedContributors = sortContributors(matchResultArray);
     return { matchResultArray, similarIssues: [], sortedContributors };
+  }
+
+  const fallback = await getRepositoryContributorFallback(context, currentRepository);
+  if (fallback) {
+    logger.debug("Using repository contributor fallback after empty similarity search", { sortedContributors: fallback.sortedContributors });
+    return { matchResultArray: fallback.matchResultArray, similarIssues: similarIssues || [], sortedContributors: fallback.sortedContributors };
   }
 
   logger.info(`Exiting issueMatching handler!`, { similarIssues: similarIssues || "No similar issues found" });
 
   return null;
+}
+
+async function getRepositoryContributorFallback(context: Context<IssueMatchingEvents>, currentRepository: RepositoryInfo | null) {
+  if (!currentRepository) {
+    context.logger.debug("Skipping repository contributor fallback because repository context is unavailable.");
+    return null;
+  }
+
+  let contributors: RepositoryContributor[];
+  try {
+    const response = await context.octokit.rest.repos.listContributors({
+      owner: currentRepository.owner,
+      repo: currentRepository.repo,
+      per_page: 100,
+    });
+    contributors = response.data as RepositoryContributor[];
+  } catch (error) {
+    context.logger.error(`Failed to fetch repository contributors: ${error}`);
+    return null;
+  }
+
+  const commitCounts = new Map<string, number>();
+  const matchResultArray: Map<string, Array<string>> = new Map();
+
+  for (const contributor of contributors) {
+    if (!isUsableContributor(contributor, context.payload.issue.user?.login)) {
+      continue;
+    }
+    const login = contributor.login as string;
+    const contributions = contributor.contributions || 0;
+    commitCounts.set(login, contributions);
+    matchResultArray.set(login, [`> \`Repository contributor fallback\` ${contributions} commits in this repository`]);
+  }
+
+  if (matchResultArray.size === 0) {
+    return null;
+  }
+
+  return {
+    matchResultArray,
+    sortedContributors: sortContributors(matchResultArray, commitCounts),
+  };
 }
 
 /**

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -381,6 +381,145 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("50% Match");
   });
 
+  it("When issue matching is triggered, it should weight same repository matches above org and global matches", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "weighted_context", 12, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+    const otherRepo = "other-repo";
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { issue_id: "same-repo", similarity: 0.8 },
+      { issue_id: "same-org", similarity: 0.8 },
+      { issue_id: "global", similarity: 0.8 },
+    ] as unknown as IssueSimilaritySearchResult[]);
+
+    const issuesById = {
+      "same-repo": {
+        node: {
+          title: "Same Repository Issue",
+          url: "https://github.com/ubiquity/test-repo/issues/10",
+          state: "closed",
+          stateReason: "COMPLETED",
+          closed: true,
+          repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+          assignees: { nodes: [{ login: "sameRepoContributor", url: "https://github.com/sameRepoContributor" }] },
+        },
+      },
+      "same-org": {
+        node: {
+          title: "Same Organization Issue",
+          url: "https://github.com/ubiquity/other-repo/issues/11",
+          state: "closed",
+          stateReason: "COMPLETED",
+          closed: true,
+          repository: { owner: { login: STRINGS.USER_1 }, name: otherRepo },
+          assignees: { nodes: [{ login: "sameOrgContributor", url: "https://github.com/sameOrgContributor" }] },
+        },
+      },
+      global: {
+        node: {
+          title: "Global Issue",
+          url: "https://github.com/other-org/other-repo/issues/12",
+          state: "closed",
+          stateReason: "COMPLETED",
+          closed: true,
+          repository: { owner: { login: "other-org" }, name: otherRepo },
+          assignees: { nodes: [{ login: "globalContributor", url: "https://github.com/globalContributor" }] },
+        },
+      },
+    };
+
+    context.octokit.graphql = mock(async (query: string, variables: { issueNodeId: keyof typeof issuesById }) => {
+      void query;
+      return issuesById[variables.issueNodeId];
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 4, "weighted_context", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "weighted_context" } } });
+    expect(comments.length).toBe(1);
+    const body = comments[0].body;
+    expect(body).toContain("sameRepoContributor");
+    expect(body).toContain("80% Match");
+    expect(body).toContain("sameOrgContributor");
+    expect(body).toContain("60% Match");
+    expect(body).toContain("globalContributor");
+    expect(body).toContain("40% Match");
+    expect(body.indexOf("sameRepoContributor")).toBeLessThan(body.indexOf("sameOrgContributor"));
+    expect(body.indexOf("sameOrgContributor")).toBeLessThan(body.indexOf("globalContributor"));
+  });
+
+  it("When no similar issues are found, it should fall back to repository contributors ordered by commit count", async () => {
+    const { context } = createContextIssues(DEFAULT_BODY, "contributor_fallback", 13, "Contributor Fallback Test");
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([]);
+    context.octokit.rest.repos.listContributors = mock(async () => ({
+      data: [
+        { login: "test", type: "User", contributions: 500 },
+        { login: "renovate[bot]", type: "Bot", contributions: 400 },
+        { login: "topContributor", type: "User", contributions: 42 },
+        { login: "secondContributor", type: "User", contributions: 7 },
+      ],
+    })) as unknown as typeof octokit.rest.repos.listContributors;
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 5, "contributor_fallback", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "contributor_fallback" } } });
+    expect(comments.length).toBe(1);
+    const body = comments[0].body;
+    expect(body).toContain("topContributor");
+    expect(body).toContain("42 commits");
+    expect(body).toContain("secondContributor");
+    expect(body).toContain("7 commits");
+    expect(body).not.toContain("renovate[bot]");
+    expect(body).not.toContain(">### [test]");
+    expect(body.indexOf("topContributor")).toBeLessThan(body.indexOf("secondContributor"));
+  });
+
+  it("When no adjusted issue match exceeds 25%, it should fall back to repository contributors", async () => {
+    const { context } = createContextIssues(DEFAULT_BODY, "low_confidence_fallback", 14, "Low Confidence Fallback Test");
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { issue_id: "global", similarity: 0.5 },
+    ] as unknown as IssueSimilaritySearchResult[]);
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Global Issue",
+        url: "https://github.com/other-org/other-repo/issues/12",
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: "other-org" }, name: "other-repo" },
+        assignees: { nodes: [{ login: "lowConfidenceContributor", url: "https://github.com/lowConfidenceContributor" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+    context.octokit.rest.repos.listContributors = mock(async () => ({
+      data: [{ login: "topFallbackContributor", type: "User", contributions: 24 }],
+    })) as unknown as typeof octokit.rest.repos.listContributors;
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 6, "low_confidence_fallback", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "low_confidence_fallback" } } });
+    expect(comments.length).toBe(1);
+    const body = comments[0].body;
+    expect(body).toContain("topFallbackContributor");
+    expect(body).toContain("24 commits");
+    expect(body).not.toContain("lowConfidenceContributor");
+    expect(body).not.toContain("25% Match");
+  });
+
   it("When an issue contains markdown links, footnotes should be added after the entire line", async () => {
     const [markdownLinkIssue1] = fetchSimilarIssues("markdown_link");
     const { context } = createContextIssues(markdownLinkIssue1.issue_body, "markdown1", 7, markdownLinkIssue1.title);
@@ -685,7 +824,7 @@ describe("Plugin tests", () => {
     comment: Context<"issue_comment.created">["payload"]["comment"] | undefined,
     eventName: Context["eventName"] = DEFAULT_HOOK
   ): Context {
-    return {
+    const context = {
       eventName: eventName,
       payload: {
         action: "created",
@@ -708,7 +847,9 @@ describe("Plugin tests", () => {
       logger: new Logs("debug") as unknown as Context["logger"],
       env: { DATABASE_URL: "postgres://db.example/text-vector-embeddings", EMBEDDINGS_QUEUE_ENABLED: "false" } as Env,
       octokit: octokit,
-    };
+    } as Context;
+    octokit.rest.repos.listContributors = mock(async () => ({ data: [] })) as unknown as typeof octokit.rest.repos.listContributors;
+    return context;
   }
 
   function createContextIssues(


### PR DESCRIPTION
## Summary
- Applies repository-aware weighting to issue recommendation matches: same repository keeps the full score, same organization uses 75%, and global matches use 50%.
- Falls back to repository contributors ordered by commit count when no adjusted issue match exceeds 25%, including the empty-similarity case.
- Filters bot contributors and the issue author from fallback recommendations.

Fixes #55

## Test Plan
- bun run build
- bun test
- bun test tests/main.test.ts
- bun run knip-ci
- git diff --check