### PR TITLE
fix: dedupe issue matching recommendations

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -221,16 +221,14 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
           }
           const similarityPercentage = Math.round(issue.similarity * 100);
           const issueLink = issue.node.url.replace(/https?:\/\/github.com/, "https://www.github.com");
-          if (matchResultArray.has(assignee.login)) {
-            matchResultArray
-              .get(assignee.login)
-              ?.push(
-                `> \`${similarityPercentage}% Match\` [${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}](${issueLink})`
-              );
+          const matchLine = `> \`${similarityPercentage}% Match\` [${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}](${issueLink})`;
+          const existingMatches = matchResultArray.get(assignee.login);
+          if (existingMatches) {
+            if (!existingMatches.includes(matchLine)) {
+              existingMatches.push(matchLine);
+            }
           } else {
-            matchResultArray.set(assignee.login, [
-              `> \`${similarityPercentage}% Match\` [${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}](${issueLink})`,
-            ]);
+            matchResultArray.set(assignee.login, [matchLine]);
           }
         });
       }


### PR DESCRIPTION
Resolves #108

## Summary
- Prevents duplicate recommendation lines from being added for the same assignee in issue matching results.
- Reuses the generated match line and only pushes it when it is not already present for that contributor.

## Verification
- `npx tsc --noEmit`
- `git diff --check`

## Notes
- I could not run the full `bun test` suite because Bun is not installed in this local environment.
- I avoided any payout, wallet, Stripe, banking, or token setup changes.

/claim #108
