### PR TITLE
fix: deduplicate contributor recommendations

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -145,6 +145,7 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
   }
   const issueContent = issue.body + issue.title;
   const matchResultArray: Map<string, Array<string>> = new Map();
+  const contributorIssueMatches: Map<string, Set<string>> = new Map();
 
   // If alwaysRecommend is enabled, use a lower threshold to ensure we get enough recommendations
   const threshold =
@@ -221,16 +222,21 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
           }
           const similarityPercentage = Math.round(issue.similarity * 100);
           const issueLink = issue.node.url.replace(/https?:\/\/github.com/, "https://www.github.com");
+          const issueKey = `${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}`;
+          const seenIssueMatches = contributorIssueMatches.get(assignee.login) ?? new Set<string>();
+
+          if (seenIssueMatches.has(issueKey)) {
+            return;
+          }
+
+          seenIssueMatches.add(issueKey);
+          contributorIssueMatches.set(assignee.login, seenIssueMatches);
+
+          const issueMatch = `> \`${similarityPercentage}% Match\` [${issueKey}](${issueLink})`;
           if (matchResultArray.has(assignee.login)) {
-            matchResultArray
-              .get(assignee.login)
-              ?.push(
-                `> \`${similarityPercentage}% Match\` [${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}](${issueLink})`
-              );
+            matchResultArray.get(assignee.login)?.push(issueMatch);
           } else {
-            matchResultArray.set(assignee.login, [
-              `> \`${similarityPercentage}% Match\` [${issue.node.repository.owner.login}/${issue.node.repository.name}#${issue.node.url.split("/").pop()}](${issueLink})`,
-            ]);
+            matchResultArray.set(assignee.login, [issueMatch]);
           }
         });
       }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -329,6 +329,42 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("98% Match");
   });
 
+
+
+  it("When issue matching returns duplicate similar issues, it should suggest each contributor once per issue", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete", 3, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { id: "similar3", issue_id: "same-node", similarity: 0.98 },
+      { id: "similar3-duplicate", issue_id: "same-node", similarity: 0.97 },
+    ]);
+
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Similar Issue: Suggest based on Similarity",
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: "contributor1", url: "https://github.com/contributor1" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 1, "task_complete", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "task_complete" } } });
+    expect(comments.length).toBe(1);
+    expect(comments[0].body.match(/>### \[contributor1\]/g)).toHaveLength(1);
+    expect(comments[0].body.match(new RegExp(`${STRINGS.USER_1}/${STRINGS.TEST_REPO}#1`, "g"))).toHaveLength(1);
+  });
+
   it("When issue matching is triggered with alwaysRecommend enabled, it should suggest contributors regardless of similarity", async () => {
     const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
     const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_always", 6, taskCompleteIssue.title);


### PR DESCRIPTION
Fixes ubiquity-os-marketplace/text-vector-embeddings#108.\n\n## Summary\n- dedupe recommendation matches per contributor + issue key before rendering\n- keep highest-ranked result order from similarity sorting\n- add regression test for duplicate similar issue rows\n\n## Test\n- npm exec --yes bun -- test tests/main.test.ts --timeout 20000