### PR TITLE
fix: post comment when annotate finds no similar issues

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -141,6 +141,12 @@ async function handleSimilarIssuesAndComments(
   commentList: CommentGraphqlResponse[]
 ) {
   if (!issueList.length && !commentList.length) {
+    await context.octokit.rest.issues.createComment({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      issue_number: payload.issue.number,
+      body: ">[!NOTE]\n>No similar issues or comments found.",
+    });
     return;
   }
   // Find existing footnotes in the body

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -634,6 +634,10 @@ describe("Plugin tests", () => {
       });
     }) as unknown as typeof octokit.rest.issues.updateComment;
 
+    context2.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 2, "no_matches", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
     await runPlugin(context2);
 
     const updatedComment = db.issueComments.findFirst({ where: { id: { equals: 1 } } }) as unknown as Context<"issue_comment.created">["payload"]["comment"];


### PR DESCRIPTION
## Summary

When the `/annotate` command runs but finds no similar issues or comments, it currently returns silently with no user feedback.

This PR adds an informative comment:

```
>[!NOTE]
>No similar issues or comments found.
```

## Changes

- `src/handlers/annotate.ts`: Post a comment when both issueList and commentList are empty
- `tests/main.test.ts`: Add mock for `createComment` in the scope-filtering test case

## Related

Fixes #81