### PR TITLE
fix: comment when annotate finds no matches

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -133,14 +133,20 @@ function filterByScope(scope: string, repoOrg: string, similarIssueRepoOrg: stri
 }
 
 async function handleSimilarIssuesAndComments(
-  context: Context,
-  payload: Context["payload"],
+  context: Context<"issue_comment.created">,
+  payload: Context<"issue_comment.created">["payload"],
   commentBody: string,
   commentId: number,
   issueList: IssueGraphqlResponse[],
   commentList: CommentGraphqlResponse[]
 ) {
   if (!issueList.length && !commentList.length) {
+    await context.octokit.rest.issues.createComment({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      issue_number: payload.issue.number,
+      body: ">[!NOTE]\n> Annotation completed successfully, but no similar issues or comments were found.",
+    });
     return;
   }
   // Find existing footnotes in the body

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -528,6 +528,46 @@ describe("Plugin tests", () => {
     expect(updatedComment.body).toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
+  it("When a user uses default annotate command and no matches are found, it should post a note comment", async () => {
+    const targetCommentId = 21;
+    const noteCommentId = 22;
+    createComment("A unique comment that should not match anything", targetCommentId, DEFAULT_ISSUE_ID);
+    const targetComment = db.issueComments.findFirst({
+      where: {
+        id: {
+          equals: targetCommentId,
+        },
+      },
+    }) as unknown as Context<"issue_comment.created">["payload"]["comment"];
+
+    const { context, comment } = createContext("/annotate", 1, 1, 2, "createAnnotateNoMatches", DEFAULT_ISSUE_ID);
+
+    context.adapters.supabase.issue.findSimilarIssues = mock().mockResolvedValue([]);
+    context.adapters.supabase.comment.findSimilarComments = mock().mockResolvedValue([]);
+    context.octokit.rest.issues.listComments = mock(async () => {
+      return { data: [targetComment, comment] };
+    }) as unknown as typeof octokit.rest.issues.listComments;
+    context.octokit.rest.issues.updateComment = mock() as unknown as typeof octokit.rest.issues.updateComment;
+    context.octokit.rest.issues.createComment = mock(async (params: { issue_number: number; body: string }) => {
+      createComment(params.body, noteCommentId, DEFAULT_ISSUE_ID, params.issue_number);
+      return { data: {} };
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const noteComment = db.issueComments.findFirst({
+      where: {
+        id: {
+          equals: noteCommentId,
+        },
+      },
+    }) as unknown as Context<"issue_comment.created">["payload"]["comment"];
+    expect(context.octokit.rest.issues.updateComment).toHaveBeenCalledTimes(0);
+    expect(context.octokit.rest.issues.createComment).toHaveBeenCalledTimes(1);
+    expect(noteComment.body).toContain("Annotation completed successfully");
+    expect(noteComment.body).toContain("no similar issues or comments were found");
+  });
+
   it("When demoFlag is true, it should skip storing issues in the database", async () => {
     const { context } = createContextIssues(DEFAULT_BODY, "demoIssue", 10, "Demo Test Issue");
 


### PR DESCRIPTION
## Summary
- post a note comment when `/annotate` completes without any issue or comment matches
- keep the existing footnote update flow unchanged when matches are found
- add regression coverage for the no-match path

## Why
The plugin currently succeeds silently when annotate finds no good matches. This gives users a clear confirmation that the command ran and simply had nothing useful to report.

## Validation
- npx bun test tests\main.test.ts --timeout 60000
- npx eslint src\handlers\annotate.ts tests\main.test.ts
- npx prettier --check src\handlers\annotate.ts tests\main.test.ts
- npx bun run build

Resolves #81
