### PR TITLE
fix: clarify inaccessible annotate comments

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -43,13 +43,25 @@ export async function annotate(context: Context<"issue_comment.created">, commen
       logger.error("No comments before the annotate command");
     }
   } else {
-    const { data } = await octokit.rest.issues.getComment({
-      owner: repository.owner.login,
-      repo: repository.name,
-      comment_id: parseInt(commentId, 10),
-    });
+    let data: Comment;
+    try {
+      ({ data } = await octokit.rest.issues.getComment({
+        owner: repository.owner.login,
+        repo: repository.name,
+        comment_id: parseInt(commentId, 10),
+      }));
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        throw logger.error("Unable to annotate this comment because it is outside the current organization or the app does not have permission to access it.");
+      }
+      throw error;
+    }
     await commentChecker(context, data, scope);
   }
+}
+
+function isNotFoundError(error: unknown): error is { status: number } {
+  return typeof error === "object" && error !== null && "status" in error && error.status === 404;
 }
 
 /**

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -640,6 +640,25 @@ describe("Plugin tests", () => {
     expect(updatedComment.body).not.toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
+  it("When a user annotates a comment outside the current organization, it should throw a clear permission error", async () => {
+    const { context } = createContext("/annotate /#issuecomment-999 org", 1, 1, 2, "createAnnotateOutsideOrg", DEFAULT_ISSUE_ID);
+
+    context.octokit.rest.issues.getComment = mock(async () => {
+      throw { status: 404 };
+    }) as unknown as typeof octokit.rest.issues.getComment;
+
+    try {
+      await runPlugin(context);
+      throw new Error("Expected annotate to reject for an inaccessible comment");
+    } catch (error) {
+      expect(error).toMatchObject({
+        logMessage: {
+          raw: "Unable to annotate this comment because it is outside the current organization or the app does not have permission to access it.",
+        },
+      });
+    }
+  });
+
   function createContext(
     commentBody: string = "Hello, world!",
     repoId: number = 1,


### PR DESCRIPTION
## Summary
- turn inaccessible explicit annotate comment lookups into a clear user-facing error
- preserve the existing behavior for accessible comments
- add regression coverage for a 404 from GitHub's comment lookup API

## Why
When `/annotate` targets a comment outside the current organization, GitHub returns a generic 404 that is hard for users to understand. This changes that path to explain that the comment is outside the current organization or inaccessible to the app.

## Validation
- npx bun test tests\main.test.ts --timeout 60000
- npx eslint src\handlers\annotate.ts tests\main.test.ts
- npx prettier --check src\handlers\annotate.ts tests\main.test.ts
- npx bun run build

Resolves #78
