### PR TITLE
fix: close duplicate issues formally

### DIFF
--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -10,6 +10,7 @@ import { findEditDistance } from "../utils/string-similarity";
 
 export interface IssueGraphqlResponse {
   node: {
+    id: string;
     title: string;
     number: number;
     url: string;
@@ -74,24 +75,28 @@ export async function issueDedupe(context: Context<"issues.opened" | "issues.edi
     const matchIssues = processedIssues.filter((issue) => parseFloat(issue.similarity) / 100 >= context.config.dedupeMatchThreshold);
     if (matchIssues.length > 0) {
       logger.info(`Similar issue which matches more than ${context.config.dedupeMatchThreshold} already exists`, { matchIssues });
+      const duplicateIssue = findMostSimilarIssue(matchIssues);
       //To the issue body, add a footnote with the link to the similar issue
       const updatedBody = await handleMatchIssuesComment(context, payload, cleanedIssueBody, processedIssues);
       const outputBody = updatedBody || cleanedIssueBody;
       const nextBody = updateComment ? appendPluginUpdateComment(outputBody, updateComment) : outputBody;
       const isBodyUnchanged = normalizeWhitespace(originalIssue.body ?? "") === normalizeWhitespace(nextBody);
-      const shouldClose = originalIssue.state !== "closed" || originalIssue.state_reason !== "not_planned";
+      const shouldClose = originalIssue.state !== "closed";
       if (isBodyUnchanged && !shouldClose) {
         logger.info("Issue body unchanged after dedupe match update", { issueNumber: originalIssue.number });
         return;
       }
-      await octokit.rest.issues.update({
-        owner: payload.repository.owner.login,
-        repo: payload.repository.name,
-        issue_number: originalIssue.number,
-        body: nextBody,
-        state: "closed",
-        state_reason: "not_planned",
-      });
+      if (!isBodyUnchanged) {
+        await octokit.rest.issues.update({
+          owner: payload.repository.owner.login,
+          repo: payload.repository.name,
+          issue_number: originalIssue.number,
+          body: nextBody,
+        });
+      }
+      if (shouldClose) {
+        await closeIssueAsDuplicate(context, originalIssue.node_id, duplicateIssue.node.id);
+      }
       return;
     }
     if (processedIssues.length > 0) {
@@ -121,6 +126,27 @@ export async function issueDedupe(context: Context<"issues.opened" | "issues.edi
 
 function matchRepoOrgToSimilarIssueRepoOrg(repoOrg: string, similarIssueRepoOrg: string, repoName: string, similarIssueRepoName: string): boolean {
   return repoOrg === similarIssueRepoOrg && repoName === similarIssueRepoName;
+}
+
+function findMostSimilarIssue(issues: IssueGraphqlResponse[]): IssueGraphqlResponse {
+  return [...issues].sort((a, b) => parseFloat(b.similarity) - parseFloat(a.similarity))[0];
+}
+
+async function closeIssueAsDuplicate(context: Context<"issues.opened" | "issues.edited">, issueId: string, duplicateIssueId: string) {
+  await context.octokit.graphql(
+    /* GraphQL */
+    `
+      mutation CloseIssueAsDuplicate($issueId: ID!, $duplicateIssueId: ID!) {
+        closeIssue(input: { issueId: $issueId, stateReason: DUPLICATE, duplicateIssueId: $duplicateIssueId }) {
+          issue {
+            id
+            state
+          }
+        }
+      }
+    `,
+    { issueId, duplicateIssueId }
+  );
 }
 
 function splitIntoSentences(text: string): string[] {
@@ -290,6 +316,7 @@ export async function processSimilarIssues(similarIssues: IssueSimilaritySearchR
             query ($issueNodeId: ID!) {
               node(id: $issueNodeId) {
                 ... on Issue {
+                  id
                   title
                   url
                   number

--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -132,21 +132,35 @@ function findMostSimilarIssue(issues: IssueGraphqlResponse[]): IssueGraphqlRespo
   return [...issues].sort((a, b) => parseFloat(b.similarity) - parseFloat(a.similarity))[0];
 }
 
+/**
+ * Closes an issue using GitHub's formal duplicate relationship so the target issue
+ * is marked as a duplicate of the most similar canonical issue.
+ *
+ * @param context The plugin context containing Octokit and logger instances.
+ * @param issueId The GraphQL node ID for the issue being closed as a duplicate.
+ * @param duplicateIssueId The GraphQL node ID for the canonical duplicate target.
+ */
 async function closeIssueAsDuplicate(context: Context<"issues.opened" | "issues.edited">, issueId: string, duplicateIssueId: string) {
-  await context.octokit.graphql(
-    /* GraphQL */
-    `
-      mutation CloseIssueAsDuplicate($issueId: ID!, $duplicateIssueId: ID!) {
-        closeIssue(input: { issueId: $issueId, stateReason: DUPLICATE, duplicateIssueId: $duplicateIssueId }) {
-          issue {
-            id
-            state
+  try {
+    await context.octokit.graphql(
+      /* GraphQL */
+      `
+        mutation CloseIssueAsDuplicate($issueId: ID!, $duplicateIssueId: ID!) {
+          closeIssue(input: { issueId: $issueId, stateReason: DUPLICATE, duplicateIssueId: $duplicateIssueId }) {
+            issue {
+              id
+              state
+            }
           }
         }
-      }
-    `,
-    { issueId, duplicateIssueId }
-  );
+      `,
+      { issueId, duplicateIssueId }
+    );
+  } catch (error) {
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    context.logger.error("Failed to close issue as a formal duplicate", { issueId, duplicateIssueId, error: normalizedError });
+    throw normalizedError;
+  }
 }
 
 function splitIntoSentences(text: string): string[] {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -229,21 +229,46 @@ describe("Plugin tests", () => {
     context2.adapters.supabase.issue.findSimilarIssues = mock().mockResolvedValue([
       { issue_id: "match1", similarity: 0.96 },
     ] as unknown as IssueSimilaritySearchResult[]);
-    context2.octokit.graphql = mock().mockResolvedValue({
-      node: {
-        title: STRINGS.SIMILAR_ISSUE,
-        url: STRINGS.ISSUE_URL,
-        number: 3,
-        lastEditedAt: "2020-01-12T17:52:02Z",
-        body: matchThresholdIssue1.issue_body,
-        repository: {
-          name: STRINGS.TEST_REPO,
-          owner: {
-            login: STRINGS.USER_1,
+    const graphqlMock = mock(async (query: string, variables: { issueNodeId?: string; issueId?: string; duplicateIssueId?: string }) => {
+      if (query.includes("closeIssue")) {
+        db.issue.update({
+          where: {
+            node_id: { equals: variables.issueId ?? "" },
+          },
+          data: {
+            state: "closed",
+            state_reason: "duplicate",
+          },
+        });
+
+        return {
+          closeIssue: {
+            issue: {
+              id: variables.issueId,
+              state: "CLOSED",
+            },
+          },
+        };
+      }
+
+      return {
+        node: {
+          id: variables.issueNodeId,
+          title: STRINGS.SIMILAR_ISSUE,
+          url: STRINGS.ISSUE_URL,
+          number: 3,
+          lastEditedAt: "2020-01-12T17:52:02Z",
+          body: matchThresholdIssue1.issue_body,
+          repository: {
+            name: STRINGS.TEST_REPO,
+            owner: {
+              login: STRINGS.USER_1,
+            },
           },
         },
-      },
-    }) as unknown as typeof context2.octokit.graphql;
+      };
+    });
+    context2.octokit.graphql = graphqlMock as unknown as typeof context2.octokit.graphql;
 
     context2.adapters.supabase.issue.createIssue = mock(async () => {
       createIssue(
@@ -259,29 +284,27 @@ describe("Plugin tests", () => {
       );
     });
 
-    context2.octokit.rest.issues.update = mock(
-      async (params: { owner: string; repo: string; issue_number: number; body?: string; state?: string; state_reason?: string }) => {
-        const updatedBody = `${matchThresholdIssue2.issue_body}\n\n>[!CAUTION]\n> This issue may be a duplicate of the following issues:\n> - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n`;
-        db.issue.update({
-          where: {
-            number: { equals: params.issue_number },
-          },
-          data: {
-            ...(params.body && { body: updatedBody }),
-            ...(params.state && { state: params.state }),
-            ...(params.state_reason && { state_reason: params.state_reason }),
-          },
-        });
-      }
-    ) as unknown as typeof octokit.rest.issues.update;
+    context2.octokit.rest.issues.update = mock(async (params: { owner: string; repo: string; issue_number: number; body?: string }) => {
+      const updatedBody = `${matchThresholdIssue2.issue_body}\n\n>[!CAUTION]\n> This issue may be a duplicate of the following issues:\n> - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n`;
+      db.issue.update({
+        where: {
+          number: { equals: params.issue_number },
+        },
+        data: {
+          ...(params.body && { body: updatedBody }),
+        },
+      });
+    }) as unknown as typeof octokit.rest.issues.update;
 
     await runPlugin(context2);
     const issue = db.issue.findFirst({ where: { number: { equals: 4 } } }) as unknown as Context["payload"]["issue"];
     expect(issue.state).toBe("closed");
-    expect(issue.state_reason).toBe("not_planned");
+    expect(issue.state_reason).toBe("duplicate");
     expect(issue.body).toContain(">[!CAUTION]");
     expect(issue.body).toContain("This issue may be a duplicate of the following issues:");
     expect(issue.body).toContain(`- [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    const closeIssueCall = graphqlMock.mock.calls.find(([query]) => `${query}`.includes("closeIssue"));
+    expect(closeIssueCall?.[1]).toEqual({ issueId: "match2", duplicateIssueId: "match1" });
   });
 
   it("When issue matching is triggered, it should suggest contributors based on similarity", async () => {


### PR DESCRIPTION
Resolves #74

## Summary
- Fetches the GraphQL issue id for similar issues used by dedupe.
- Uses GitHub's formal duplicate close mutation with `stateReason: DUPLICATE` and `duplicateIssueId` for high-confidence duplicate matches.
- Keeps the existing caution body update separate from the close operation.
- Adds failure logging around the duplicate-close mutation.

## Verification
- bun test tests/main.test.ts --timeout 15000
- bun test tests/main.test.ts --test-name-pattern "similarity above match threshold"
- bunx prettier --check src/handlers/issue-deduplication.ts tests/main.test.ts
- bunx eslint src/handlers/issue-deduplication.ts tests/main.test.ts
- bun run build