### PR TITLE
Avoid duplicate matchmaking comments on labels

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -57,6 +57,7 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
 
   //Check if the comment already exists
   const existingComment = listIssues.find((comment) => comment.body && comment.body.includes(">[!NOTE]" + "\n" + commentStart));
+  const shouldCreateComment = context.eventName !== "issues.labeled";
 
   if (matchResultArray.size === 0) {
     if (existingComment) {
@@ -86,13 +87,15 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
       comment_id: existingComment.id,
       body: comment,
     });
-  } else {
+  } else if (shouldCreateComment) {
     await context.octokit.rest.issues.createComment({
       owner: payload.repository.owner.login,
       repo: payload.repository.name,
       issue_number: payload.issue.number,
       body: comment,
     });
+  } else {
+    logger.debug("Skipping matchmaking comment creation for label event without an existing recommendation comment.");
   }
 }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -329,6 +329,35 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("98% Match");
   });
 
+  it("When issue matching is triggered by a label event without an existing recommendation, it should not create a matchmaking comment", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete", 8, taskCompleteIssue.title);
+    context.eventName = "issues.labeled";
+
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Similar Issue: Suggest based on Similarity",
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: "contributor1", url: "https://github.com/contributor1" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    let createdComments = 0;
+    context.octokit.rest.issues.createComment = mock(async () => {
+      createdComments += 1;
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "task_complete" } } });
+    expect(createdComments).toBe(0);
+    expect(comments.length).toBe(0);
+  });
+
   it("When issue matching is triggered with alwaysRecommend enabled, it should suggest contributors regardless of similarity", async () => {
     const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
     const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_always", 6, taskCompleteIssue.title);


### PR DESCRIPTION
Resolves #94

## Summary

- prevent issues.labeled events from creating new matchmaking recommendation comments
- preserve updates to an existing recommendation comment
- add a regression test for label-triggered issue matching without an existing recommendation

## Verification

- bun test tests/main.test.ts --timeout 90000
- bun run prepare:manifest
- tsc --noEmit
- bun test --timeout 90000
- prettier check
- git diff --check