### PR TITLE
fix: clarify inaccessible annotation comment errors

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -23,6 +23,34 @@ interface CommentGraphqlResponse {
   mostSimilarSentence: { sentence: string; similarity: number; index: number };
 }
 
+interface RequestErrorWithStatus {
+  status: number;
+}
+
+function hasRequestStatus(error: object): error is RequestErrorWithStatus {
+  return "status" in error && typeof error.status === "number";
+}
+
+async function fetchCommentForAnnotation(context: Context<"issue_comment.created">, commentId: number): Promise<Comment> {
+  const { logger, octokit, payload } = context;
+  const repository = payload.repository;
+  try {
+    const { data } = await octokit.rest.issues.getComment({
+      owner: repository.owner.login,
+      repo: repository.name,
+      comment_id: commentId,
+    });
+    return data;
+  } catch (error) {
+    if (typeof error === "object" && error !== null && hasRequestStatus(error) && error.status === 404) {
+      throw logger.error(
+        `Unable to fetch issue comment ${commentId} from ${repository.owner.login}/${repository.name}. The comment may be outside the current organization or repository, or the app may not have permission to read it.`
+      );
+    }
+    throw error;
+  }
+}
+
 export async function annotate(context: Context<"issue_comment.created">, commentId: string | null, scope: string) {
   const { logger, octokit, payload } = context;
 
@@ -43,12 +71,8 @@ export async function annotate(context: Context<"issue_comment.created">, commen
       logger.error("No comments before the annotate command");
     }
   } else {
-    const { data } = await octokit.rest.issues.getComment({
-      owner: repository.owner.login,
-      repo: repository.name,
-      comment_id: parseInt(commentId, 10),
-    });
-    await commentChecker(context, data, scope);
+    const comment = await fetchCommentForAnnotation(context, parseInt(commentId, 10));
+    await commentChecker(context, comment, scope);
   }
 }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -528,6 +528,32 @@ describe("Plugin tests", () => {
     expect(updatedComment.body).toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
+  it("When a user annotates an inaccessible comment, it should return a clear error", async () => {
+    const inaccessibleCommentId = 999;
+    const expectedMessage = `Unable to fetch issue comment ${inaccessibleCommentId} from ${STRINGS.USER_1}/${STRINGS.TEST_REPO}. The comment may be outside the current organization or repository, or the app may not have permission to read it.`;
+    const { context, errorSpy } = createContext(
+      `/annotate https://github.com/external-org/external-repo/issues/1#issuecomment-${inaccessibleCommentId} repo`,
+      1,
+      1,
+      2,
+      "createAnnotateExternal"
+    );
+
+    Object.assign(context.octokit.rest.issues, {
+      getComment: mock(async () => {
+        throw { status: 404, message: "Not Found" };
+      }),
+    });
+
+    const rejection = await runPlugin(context).then(
+      () => null,
+      (error: object) => error
+    );
+
+    expect(rejection).toMatchObject({ logMessage: { raw: expectedMessage } });
+    expect(errorSpy).toHaveBeenCalledWith(expectedMessage);
+  });
+
   it("When demoFlag is true, it should skip storing issues in the database", async () => {
     const { context } = createContextIssues(DEFAULT_BODY, "demoIssue", 10, "Demo Test Issue");
 


### PR DESCRIPTION
Resolves #78

## Changes

- Adds a clear error when `/annotate` cannot fetch an explicit issue comment from the current repository context.
- Keeps successful annotation behavior unchanged.
- Preserves non-404 GitHub errors for debugging.
- Adds focused coverage for a mocked GitHub `Not Found` response.

## Validation

- [x] bun run build
- [x] bun test tests/main.test.ts
- [x] bun test
- [x] bun run eslint --fix-dry-run
- [x] bun run prettier --check .

Note: `/start` on the issue appears restricted for Priority 2 tasks, so maintainer assignment or guidance may be needed for bounty claiming.