### PR TITLE
Handle out-of-org annotate URLs clearly

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -23,12 +23,25 @@ interface CommentGraphqlResponse {
   mostSimilarSentence: { sentence: string; similarity: number; index: number };
 }
 
-export async function annotate(context: Context<"issue_comment.created">, commentId: string | null, scope: string) {
+interface CommentTargetRepository {
+  owner: {
+    login: string;
+  };
+  name: string;
+}
+
+export interface AnnotateCommentReference {
+  id: string;
+  owner?: string;
+  repo?: string;
+}
+
+export async function annotate(context: Context<"issue_comment.created">, commentReference: AnnotateCommentReference | null, scope: string) {
   const { logger, octokit, payload } = context;
 
   const repository = payload.repository;
 
-  if (!commentId) {
+  if (!commentReference) {
     const response = await octokit.rest.issues.listComments({
       owner: repository.owner.login,
       repo: repository.name,
@@ -43,12 +56,41 @@ export async function annotate(context: Context<"issue_comment.created">, commen
       logger.error("No comments before the annotate command");
     }
   } else {
+    validateCommentReferenceScope(context, commentReference, scope);
+    const targetRepository = {
+      owner: { login: commentReference.owner ?? repository.owner.login },
+      name: commentReference.repo ?? repository.name,
+    };
     const { data } = await octokit.rest.issues.getComment({
-      owner: repository.owner.login,
-      repo: repository.name,
-      comment_id: parseInt(commentId, 10),
+      owner: targetRepository.owner.login,
+      repo: targetRepository.name,
+      comment_id: parseInt(commentReference.id, 10),
     });
-    await commentChecker(context, data, scope);
+    await commentChecker(context, data, scope, targetRepository);
+  }
+}
+
+function validateCommentReferenceScope(context: Context<"issue_comment.created">, commentReference: AnnotateCommentReference, scope: string) {
+  if (!commentReference.owner || !commentReference.repo) {
+    return;
+  }
+
+  const { logger, payload } = context;
+  const currentOwner = payload.repository.owner.login;
+  const currentRepo = payload.repository.name;
+  const isSameOwner = commentReference.owner.toLowerCase() === currentOwner.toLowerCase();
+  const isSameRepo = isSameOwner && commentReference.repo.toLowerCase() === currentRepo.toLowerCase();
+
+  if (scope === "org" && !isSameOwner) {
+    throw logger.error(
+      `Cannot annotate a comment outside the current organization. ${commentReference.owner}/${commentReference.repo} is outside ${currentOwner}.`
+    );
+  }
+
+  if (scope === "repo" && !isSameRepo) {
+    throw logger.error(
+      `Cannot annotate a comment outside the current repository. ${commentReference.owner}/${commentReference.repo} is outside ${currentOwner}/${currentRepo}.`
+    );
   }
 }
 
@@ -59,7 +101,12 @@ export async function annotate(context: Context<"issue_comment.created">, commen
  * @param comment The comment object
  * @param scope The scope of the annotation
  **/
-export async function commentChecker(context: Context<"issue_comment.created">, comment: Comment, scope: string) {
+export async function commentChecker(
+  context: Context<"issue_comment.created">,
+  comment: Comment,
+  scope: string,
+  targetRepository: CommentTargetRepository = context.payload.repository
+) {
   const {
     logger,
     adapters: { supabase },
@@ -116,7 +163,7 @@ export async function commentChecker(context: Context<"issue_comment.created">, 
   } else {
     context.logger.info("No similar comments found for comment", { commentBody });
   }
-  await handleSimilarIssuesAndComments(context, payload, commentBody, comment.id, processedIssues, processedComments);
+  await handleSimilarIssuesAndComments(context, commentBody, comment.id, processedIssues, processedComments, targetRepository);
 }
 
 function filterByScope(scope: string, repoOrg: string, similarIssueRepoOrg: string, repoName: string, similarIssueRepoName: string): boolean {
@@ -134,11 +181,11 @@ function filterByScope(scope: string, repoOrg: string, similarIssueRepoOrg: stri
 
 async function handleSimilarIssuesAndComments(
   context: Context,
-  payload: Context["payload"],
   commentBody: string,
   commentId: number,
   issueList: IssueGraphqlResponse[],
-  commentList: CommentGraphqlResponse[]
+  commentList: CommentGraphqlResponse[],
+  targetRepository: CommentTargetRepository
 ) {
   if (!issueList.length && !commentList.length) {
     return;
@@ -219,8 +266,8 @@ async function handleSimilarIssuesAndComments(
   }
   // Update the comment with the modified body
   await context.octokit.rest.issues.updateComment({
-    owner: payload.repository.owner.login,
-    repo: payload.repository.name,
+    owner: targetRepository.owner.login,
+    repo: targetRepository.name,
     comment_id: commentId,
     body: updatedBody,
   });

--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -1,5 +1,5 @@
 import { Context } from "../types/index";
-import { annotate } from "./annotate";
+import { annotate, type AnnotateCommentReference } from "./annotate";
 import { issueMatching, issueMatchingForUsers } from "./issue-matching";
 
 // GitHub usernames are 1-39 chars, alphanumeric or hyphen, no leading/trailing hyphen.
@@ -45,6 +45,20 @@ async function postCommandResponse(context: Context<"issue_comment.created">, bo
   await context.commentHandler.postComment(context, context.logger.info(body), options);
 }
 
+function parseCommentReference(commentUrl: string): AnnotateCommentReference | null {
+  const fullUrlMatch = commentUrl.match(/^https:\/\/(?:www\.)?github\.com\/([^/\s]+)\/([^/\s]+)\/(?:issues|pull)\/\d+#issuecomment-(\d+)$/i);
+  if (fullUrlMatch) {
+    return {
+      owner: fullUrlMatch[1],
+      repo: fullUrlMatch[2],
+      id: fullUrlMatch[3],
+    };
+  }
+
+  const idOnlyMatch = commentUrl.match(/#issuecomment-(\d+)$/);
+  return idOnlyMatch ? { id: idOnlyMatch[1] } : null;
+}
+
 export async function commandHandler(context: Context<"issue_comment.created">) {
   const { logger } = context;
 
@@ -55,16 +69,14 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
   if (context.command.name === "annotate") {
     const commentUrl = context.command.parameters.commentUrl ?? null;
     const scope = context.command.parameters.scope ?? "org";
-    let commentId = null;
+    let commentReference = null;
     if (commentUrl) {
-      const commentRegex = /#issuecomment-(\d+)$/;
-      const match = commentUrl.match(commentRegex);
-      if (!match) {
+      commentReference = parseCommentReference(commentUrl);
+      if (!commentReference) {
         throw logger.error("Invalid comment URL");
       }
-      commentId = match[1];
     }
-    await annotate(context, commentId, scope);
+    await annotate(context, commentReference, scope);
   }
 }
 
@@ -74,7 +86,7 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
   const splitComment = comment.body.trim().split(/\s+/);
   const commandName = splitComment[0].replace("/", "");
 
-  let commentId = null;
+  let commentReference = null;
   let scope = "org";
 
   if (commandName === "annotate") {
@@ -87,17 +99,15 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
           throw logger.error("Invalid scope");
         }
 
-        const commentRegex = /#issuecomment-(\d+)$/;
-        const match = commentUrl.match(commentRegex);
-        if (!match) {
+        commentReference = parseCommentReference(commentUrl);
+        if (!commentReference) {
           throw logger.error("Invalid comment URL");
         }
-        commentId = match[1];
       } else {
         throw logger.error("Invalid parameters");
       }
     }
-    await annotate(context, commentId, scope);
+    await annotate(context, commentReference, scope);
   }
 
   if (commandName === "recommendation") {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -640,6 +640,32 @@ describe("Plugin tests", () => {
     expect(updatedComment.body).not.toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
+  it("When a user annotates a comment outside the current organization with org scope, it should throw a clear error before fetching the comment", async () => {
+    createContextIssues("Target issue", "annotate", 9, "Annotate target");
+    const { context: context2 } = createContext(
+      "/annotate https://github.com/external-org/external-repo/issues/1#issuecomment-1 org",
+      1,
+      1,
+      2,
+      "createAnnotate",
+      "annotate"
+    );
+    const getCommentMock = mock(async () => {
+      throw new Error("The comment should not be fetched when it is outside the current organization");
+    });
+    context2.octokit.rest.issues.getComment = getCommentMock as unknown as typeof octokit.rest.issues.getComment;
+
+    let thrown: unknown;
+    try {
+      await runPlugin(context2);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect((thrown as { logMessage?: { raw?: string } })?.logMessage?.raw).toContain("Cannot annotate a comment outside the current organization");
+    expect(getCommentMock).not.toHaveBeenCalled();
+  });
+
   function createContext(
     commentBody: string = "Hello, world!",
     repoId: number = 1,


### PR DESCRIPTION
## Summary
- Parse full GitHub issue/pull comment URLs so annotate commands keep the target owner/repo.
- Reject out-of-organization URLs for `org` scope and out-of-repository URLs for `repo` scope before calling `getComment`.
- Update annotation writes to use the parsed target repository when a full comment URL is supplied.

## Tests
- `npx eslint src/handlers/annotate.ts src/handlers/user-annotate.ts tests/main.test.ts`
- `npx tsc --noEmit --moduleResolution bundler --module ESNext --target ESNext --esModuleInterop --strict --skipLibCheck --resolveJsonModule src/handlers/annotate.ts src/handlers/user-annotate.ts`
- `npx bun test tests/main.test.ts --timeout 60000`

Fixes #78