### PR TITLE
Prune duplicate matchmaking comments

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -31,6 +31,9 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+const MATCHMAKING_COMMENT_START = ">The following contributors may be suitable for this task:";
+const MATCHMAKING_COMMENT_MARKER = `>[!NOTE]\n${MATCHMAKING_COMMENT_START}`;
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
 }
@@ -38,7 +41,6 @@ function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResp
 export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
   const { logger, octokit, payload } = context;
   const issue = payload.issue;
-  const commentStart = ">The following contributors may be suitable for this task:";
 
   const result = await issueMatching(context);
 
@@ -56,7 +58,7 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
   })) as IssueCommentSummary[];
 
   //Check if the comment already exists
-  const existingComment = listIssues.find((comment) => comment.body && comment.body.includes(">[!NOTE]" + "\n" + commentStart));
+  const existingComment = listIssues.find(isMatchmakingComment);
 
   if (matchResultArray.size === 0) {
     if (existingComment) {
@@ -66,6 +68,7 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
         repo: payload.repository.name,
         comment_id: existingComment.id,
       });
+      await cleanupDuplicateMatchmakingComments(context);
     }
     logger.debug("No suitable contributors found");
     return;
@@ -94,6 +97,32 @@ export async function issueMatchingWithComment(context: Context<"issues.opened" 
       body: comment,
     });
   }
+  await cleanupDuplicateMatchmakingComments(context);
+}
+
+function isMatchmakingComment(comment: IssueCommentSummary): boolean {
+  return !!comment.body?.includes(MATCHMAKING_COMMENT_MARKER);
+}
+
+async function cleanupDuplicateMatchmakingComments(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
+  const { octokit, payload } = context;
+  const comments = (await octokit.paginate(octokit.rest.issues.listComments, {
+    owner: payload.repository.owner.login,
+    repo: payload.repository.name,
+    issue_number: payload.issue.number,
+  })) as IssueCommentSummary[];
+  const matchmakingComments = comments.filter(isMatchmakingComment).sort((a, b) => a.id - b.id);
+  const duplicateComments = matchmakingComments.slice(1);
+
+  await Promise.all(
+    duplicateComments.map((comment) =>
+      octokit.rest.issues.deleteComment({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        comment_id: comment.id,
+      })
+    )
+  );
 }
 
 type IssueMatchingEvents = "issues.opened" | "issues.edited" | "issues.labeled" | "issue_comment.created";

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -329,6 +329,80 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("98% Match");
   });
 
+  it("When issue matching finds duplicate matchmaking comments, it should keep the first one and delete the rest", async () => {
+    const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
+    const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_duplicates", 6, taskCompleteIssue.title);
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.createIssue = mock(async () => {
+      createIssue(
+        taskCompleteIssue.issue_body,
+        "task_complete_duplicates",
+        taskCompleteIssue.title,
+        6,
+        { login: "test", id: 1 },
+        "open",
+        null,
+        STRINGS.TEST_REPO,
+        STRINGS.USER_1
+      );
+    });
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { issue_id: "similar3", similarity: 0.98 },
+    ] as unknown as IssueSimilaritySearchResult[]);
+    context.octokit.graphql = mock().mockResolvedValue({
+      node: {
+        title: "Similar Issue: Suggest based on Similarity",
+        url: STRINGS.ISSUE_URL_TEMPLATE,
+        state: "closed",
+        stateReason: "COMPLETED",
+        closed: true,
+        repository: { owner: { login: STRINGS.USER_1 }, name: STRINGS.TEST_REPO },
+        assignees: { nodes: [{ login: "contributor1", url: "https://github.com/contributor1" }] },
+      },
+    }) as unknown as typeof context.octokit.graphql;
+
+    const matchmakingBody = ">[!NOTE]\n>The following contributors may be suitable for this task:\n> stale";
+    const originalPaginate = context.octokit.paginate;
+    const originalUpdateComment = context.octokit.rest.issues.updateComment;
+    const originalDeleteComment = context.octokit.rest.issues.deleteComment;
+    const originalCreateComment = context.octokit.rest.issues.createComment;
+    context.octokit.paginate = mock(async () => [
+      { id: 1, body: matchmakingBody },
+      { id: 2, body: matchmakingBody },
+    ]) as unknown as typeof context.octokit.paginate;
+    let updatedCommentId: number | null = null;
+    context.octokit.rest.issues.updateComment = mock(async (params: { comment_id: number }) => {
+      updatedCommentId = params.comment_id;
+    }) as unknown as typeof octokit.rest.issues.updateComment;
+    const deletedCommentIds: number[] = [];
+    context.octokit.rest.issues.deleteComment = mock(async (params: { comment_id: number }) => {
+      deletedCommentIds.push(params.comment_id);
+    }) as unknown as typeof octokit.rest.issues.deleteComment;
+    const createCommentMock = mock(async () => {});
+    context.octokit.rest.issues.createComment = createCommentMock as unknown as typeof octokit.rest.issues.createComment;
+
+    let runError: unknown;
+    try {
+      await runPlugin(context);
+    } catch (error) {
+      runError = error;
+    } finally {
+      context.octokit.paginate = originalPaginate;
+      context.octokit.rest.issues.updateComment = originalUpdateComment;
+      context.octokit.rest.issues.deleteComment = originalDeleteComment;
+      context.octokit.rest.issues.createComment = originalCreateComment;
+    }
+
+    if (runError) {
+      throw runError;
+    }
+
+    expect(updatedCommentId).toBe(1);
+    expect(deletedCommentIds).toEqual([2]);
+    expect(createCommentMock).not.toHaveBeenCalled();
+  });
+
   it("When issue matching is triggered with alwaysRecommend enabled, it should suggest contributors regardless of similarity", async () => {
     const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
     const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_always", 6, taskCompleteIssue.title);


### PR DESCRIPTION
## Summary
- Reuse a single matchmaking comment marker for detection.
- After posting/updating matchmaking recommendations, re-list matching comments and delete duplicates, keeping the oldest comment as the canonical one.
- Add a regression test that simulates duplicate matchmaking comments and verifies the first is updated, the duplicate is deleted, and no new comment is created.

## Tests
- `npx eslint src/handlers/issue-matching.ts tests/main.test.ts`
- `npx tsc --noEmit --moduleResolution bundler --module ESNext --target ESNext --esModuleInterop --strict --skipLibCheck --resolveJsonModule src/handlers/issue-matching.ts`
- `npx bun test tests/main.test.ts --timeout 60000`
- `git diff --check`

Fixes #94