### PR TITLE
fix: clarify annotate errors for external comments

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -23,7 +23,17 @@ interface CommentGraphqlResponse {
   mostSimilarSentence: { sentence: string; similarity: number; index: number };
 }
 
-export async function annotate(context: Context<"issue_comment.created">, commentId: string | null, scope: string) {
+export interface AnnotationSourceRepository {
+  owner: string;
+  repo: string;
+}
+
+export async function annotate(
+  context: Context<"issue_comment.created">,
+  commentId: string | null,
+  scope: string,
+  sourceRepository?: AnnotationSourceRepository
+) {
   const { logger, octokit, payload } = context;
 
   const repository = payload.repository;
@@ -43,11 +53,23 @@ export async function annotate(context: Context<"issue_comment.created">, commen
       logger.error("No comments before the annotate command");
     }
   } else {
-    const { data } = await octokit.rest.issues.getComment({
+    const source = sourceRepository ?? {
       owner: repository.owner.login,
       repo: repository.name,
-      comment_id: parseInt(commentId, 10),
-    });
+    };
+    let data;
+    try {
+      ({ data } = await octokit.rest.issues.getComment({
+        owner: source.owner,
+        repo: source.repo,
+        comment_id: parseInt(commentId, 10),
+      }));
+    } catch (error) {
+      throw logger.error(
+        `Unable to fetch comment ${commentId} from ${source.owner}/${source.repo}. Make sure the comment URL belongs to a repository this plugin can access.`,
+        { error: error instanceof Error ? error : new Error(String(error)) }
+      );
+    }
     await commentChecker(context, data, scope);
   }
 }

--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -1,5 +1,5 @@
 import { Context } from "../types/index";
-import { annotate } from "./annotate";
+import { annotate, type AnnotationSourceRepository } from "./annotate";
 import { issueMatching, issueMatchingForUsers } from "./issue-matching";
 
 // GitHub usernames are 1-39 chars, alphanumeric or hyphen, no leading/trailing hyphen.
@@ -40,14 +40,53 @@ function buildRecommendationComment(result: NonNullable<Awaited<ReturnType<typeo
   return lines.join("\n");
 }
 
+function parseCommentUrl(commentUrl: string) {
+  const match = commentUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/\d+#issuecomment-(\d+)$/);
+  if (!match) {
+    return null;
+  }
+  const [, owner, repo, commentId] = match;
+  return { owner, repo, commentId };
+}
+
+function getAnnotationSource(
+  context: Context<"issue_comment.created">,
+  commentUrl: string | null,
+  scope: string
+): { commentId: string | null; sourceRepository?: AnnotationSourceRepository } {
+  if (!commentUrl) {
+    return { commentId: null };
+  }
+  const parsedComment = parseCommentUrl(commentUrl);
+  if (!parsedComment) {
+    throw context.logger.error("Invalid comment URL");
+  }
+
+  const currentOwner = context.payload.repository.owner.login;
+  const currentRepo = context.payload.repository.name;
+  const sourceRepository = { owner: parsedComment.owner, repo: parsedComment.repo };
+
+  if (scope === "repo" && (sourceRepository.owner !== currentOwner || sourceRepository.repo !== currentRepo)) {
+    throw context.logger.error(
+      `Cannot annotate comment ${parsedComment.commentId} with repo scope because it belongs to ${sourceRepository.owner}/${sourceRepository.repo}, outside the current repository ${currentOwner}/${currentRepo}.`
+    );
+  }
+
+  if (scope === "org" && sourceRepository.owner !== currentOwner) {
+    throw context.logger.error(
+      `Cannot annotate comment ${parsedComment.commentId} with org scope because it belongs to ${sourceRepository.owner}/${sourceRepository.repo}, outside the current organization ${currentOwner}. Use global scope only when the plugin has access to that repository.`
+    );
+  }
+
+  return { commentId: parsedComment.commentId, sourceRepository };
+}
+
 async function postCommandResponse(context: Context<"issue_comment.created">, body: string, forceTag = false) {
   const options = forceTag ? { raw: true, commentKind: "command-response" } : { raw: true };
   await context.commentHandler.postComment(context, context.logger.info(body), options);
 }
 
 export async function commandHandler(context: Context<"issue_comment.created">) {
-  const { logger } = context;
-
   if (!context.command) {
     return;
   }
@@ -55,16 +94,8 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
   if (context.command.name === "annotate") {
     const commentUrl = context.command.parameters.commentUrl ?? null;
     const scope = context.command.parameters.scope ?? "org";
-    let commentId = null;
-    if (commentUrl) {
-      const commentRegex = /#issuecomment-(\d+)$/;
-      const match = commentUrl.match(commentRegex);
-      if (!match) {
-        throw logger.error("Invalid comment URL");
-      }
-      commentId = match[1];
-    }
-    await annotate(context, commentId, scope);
+    const { commentId, sourceRepository } = getAnnotationSource(context, commentUrl, scope);
+    await annotate(context, commentId, scope, sourceRepository);
   }
 }
 
@@ -86,13 +117,10 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
         if (scope !== "global" && scope !== "org" && scope !== "repo") {
           throw logger.error("Invalid scope");
         }
-
-        const commentRegex = /#issuecomment-(\d+)$/;
-        const match = commentUrl.match(commentRegex);
-        if (!match) {
-          throw logger.error("Invalid comment URL");
-        }
-        commentId = match[1];
+        const annotationSource = getAnnotationSource(context, commentUrl, scope);
+        commentId = annotationSource.commentId;
+        await annotate(context, commentId, scope, annotationSource.sourceRepository);
+        return;
       } else {
         throw logger.error("Invalid parameters");
       }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -528,6 +528,51 @@ describe("Plugin tests", () => {
     expect(updatedComment.body).toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
+  it("When annotate command points outside the current organization, it should explain the scope mismatch", async () => {
+    const { context } = createContext("/annotate", 1, 1, 2, "outsideOrgAnnotate", "annotate");
+    context.command = {
+      name: "annotate",
+      parameters: {
+        commentUrl: "https://github.com/outside-org/external-repo/issues/1#issuecomment-123",
+        scope: "org",
+      },
+    };
+
+    let error: unknown;
+    try {
+      await runPlugin(context);
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("outside the current organization ubiquity");
+  });
+
+  it("When annotate command points to another repository in the current organization, it should fetch the comment from that repository", async () => {
+    const { context } = createContext("/annotate", 1, 1, 2, "sameOrgAnnotate", "annotate");
+    context.command = {
+      name: "annotate",
+      parameters: {
+        commentUrl: `https://github.com/${STRINGS.USER_1}/${STRINGS.TEST_REPO_2}/issues/1#issuecomment-${annotateComment.id}`,
+        scope: "org",
+      },
+    };
+    context.adapters.supabase.issue.findSimilarIssues = mock().mockResolvedValue([]);
+    context.adapters.supabase.comment.findSimilarComments = mock().mockResolvedValue([]);
+    const getComment = mock(async (params: { owner: string; repo: string; comment_id: number }) => {
+      expect(params.owner).toBe(STRINGS.USER_1);
+      expect(params.repo).toBe(STRINGS.TEST_REPO_2);
+      expect(params.comment_id).toBe(annotateComment.id);
+      return { data: annotateComment };
+    });
+    context.octokit.rest.issues.getComment = getComment as unknown as typeof octokit.rest.issues.getComment;
+
+    await runPlugin(context);
+
+    expect(getComment).toHaveBeenCalledTimes(1);
+  });
+
   it("When demoFlag is true, it should skip storing issues in the database", async () => {
     const { context } = createContextIssues(DEFAULT_BODY, "demoIssue", 10, "Demo Test Issue");
 


### PR DESCRIPTION
Resolves #78

Summary:
- Parse annotate comment URLs to identify the source repository.
- Return a clear error when org/repo scope points outside the current allowed scope.
- Fetch same-organization comments from the repository in the provided URL.
- Added regression coverage for external-org and same-org cross-repo annotate URLs.

Validation:
- ESLint passed for changed files.
- TypeScript check shows no errors in changed files.
