### PR TITLE
fix: clarify annotate external comment errors

### DIFF
--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -45,9 +45,44 @@ async function postCommandResponse(context: Context<"issue_comment.created">, bo
   await context.commentHandler.postComment(context, context.logger.info(body), options);
 }
 
-export async function commandHandler(context: Context<"issue_comment.created">) {
-  const { logger } = context;
+function parseCommentIdFromUrl(context: Context<"issue_comment.created">, commentUrl: string): string {
+  const match = commentUrl.match(/#issuecomment-(\d+)$/);
+  if (!match) {
+    throw context.logger.error("Invalid comment URL");
+  }
 
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(commentUrl);
+  } catch {
+    return match[1];
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  if (hostname !== "github.com" && hostname !== "www.github.com") {
+    throw context.logger.error("Invalid comment URL");
+  }
+
+  const [owner, repo, resource, resourceId] = parsedUrl.pathname.split("/").filter(Boolean);
+  if (!owner || !repo || (resource !== "issues" && resource !== "pull") || !resourceId) {
+    throw context.logger.error("Invalid comment URL");
+  }
+
+  const currentOwner = context.payload.repository.owner.login;
+  const currentRepo = context.payload.repository.name;
+  const isCurrentRepository = owner.toLowerCase() === currentOwner.toLowerCase() && repo.toLowerCase() === currentRepo.toLowerCase();
+  if (!isCurrentRepository) {
+    const message =
+      `Cannot annotate comment from ${owner}/${repo}. ` +
+      `The comment URL must belong to the current repository ${currentOwner}/${currentRepo}; ` +
+      "comments outside the current organization or without installation access cannot be annotated.";
+    throw context.logger.error(message);
+  }
+
+  return match[1];
+}
+
+export async function commandHandler(context: Context<"issue_comment.created">) {
   if (!context.command) {
     return;
   }
@@ -57,12 +92,7 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
     const scope = context.command.parameters.scope ?? "org";
     let commentId = null;
     if (commentUrl) {
-      const commentRegex = /#issuecomment-(\d+)$/;
-      const match = commentUrl.match(commentRegex);
-      if (!match) {
-        throw logger.error("Invalid comment URL");
-      }
-      commentId = match[1];
+      commentId = parseCommentIdFromUrl(context, commentUrl);
     }
     await annotate(context, commentId, scope);
   }
@@ -87,12 +117,7 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
           throw logger.error("Invalid scope");
         }
 
-        const commentRegex = /#issuecomment-(\d+)$/;
-        const match = commentUrl.match(commentRegex);
-        if (!match) {
-          throw logger.error("Invalid comment URL");
-        }
-        commentId = match[1];
+        commentId = parseCommentIdFromUrl(context, commentUrl);
       } else {
         throw logger.error("Invalid parameters");
       }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -640,6 +640,33 @@ describe("Plugin tests", () => {
     expect(updatedComment.body).not.toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
+  it("When a user annotates a comment URL outside the current repository, it should explain the permission boundary", async () => {
+    createIssue("Annotate target", "annotate", "Annotate Target", 22, { login: "test", id: 1 }, "open", null, STRINGS.TEST_REPO, STRINGS.USER_1);
+    const { context, errorSpy } = createContext(
+      "/annotate https://github.com/koya0/.ubiquity-os/issues/22#issuecomment-2535532258 repo",
+      1,
+      1,
+      2,
+      "outsideRepoAnnotate",
+      "annotate"
+    );
+    const getCommentMock = mock(async () => ({ data: annotateComment })) as unknown as typeof octokit.rest.issues.getComment;
+    context.octokit.rest.issues.getComment = getCommentMock;
+
+    let thrown: unknown;
+    try {
+      await runPlugin(context);
+    } catch (error) {
+      thrown = error;
+    }
+
+    const errorMessages = errorSpy.mock.calls.map(([message]) => String(message));
+    const errorText = [String(thrown), ...errorMessages].join("\n");
+    expect(errorText.includes("Cannot annotate comment from koya0/.ubiquity-os")).toBe(true);
+    expect(errorText.includes("outside the current organization")).toBe(true);
+    expect(getCommentMock).not.toHaveBeenCalled();
+  });
+
   function createContext(
     commentBody: string = "Hello, world!",
     repoId: number = 1,


### PR DESCRIPTION
Resolves #78

## Summary
- Parse explicit GitHub issue-comment URLs before /annotate calls issues.getComment.
- Reject comment URLs outside the current repository/access boundary with a clear message instead of surfacing GitHub's generic Not Found.
- Preserve existing fragment-only #issuecomment support for current-repository comments.

## Tests
- npx --yes prettier@3.3.2 --check src/handlers/user-annotate.ts tests/main.test.ts
- npx --yes bun@1.2.19 test tests/main.test.ts -t "outside the current repository"
- npx --yes bun@1.2.19 test tests/main.test.ts
- .\node_modules\.bin\tsc --noEmit --pretty false --skipLibCheck --moduleResolution bundler --module ESNext --target ESNext --esModuleInterop --useDefineForClassFields false src/handlers/user-annotate.ts

Note: full tsc without the focused flags expects generated manifest.json from the repo prebuild step, so I avoided running generation scripts for this small fix.