### PR TITLE
fix: reject scheme-less annotate URLs

### DIFF
--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -45,9 +45,44 @@ async function postCommandResponse(context: Context<"issue_comment.created">, bo
   await context.commentHandler.postComment(context, context.logger.info(body), options);
 }
 
-export async function commandHandler(context: Context<"issue_comment.created">) {
-  const { logger } = context;
+function parseCommentIdFromUrl(context: Context<"issue_comment.created">, commentUrl: string): string {
+  const match = commentUrl.match(/#issuecomment-(\d+)$/);
+  if (!match) {
+    throw context.logger.error("Invalid comment URL");
+  }
 
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(commentUrl);
+  } catch {
+    return match[1];
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  if (hostname !== "github.com" && hostname !== "www.github.com") {
+    throw context.logger.error("Invalid comment URL");
+  }
+
+  const [owner, repo, resource, resourceId] = parsedUrl.pathname.split("/").filter(Boolean);
+  if (!owner || !repo || (resource !== "issues" && resource !== "pull") || !resourceId) {
+    throw context.logger.error("Invalid comment URL");
+  }
+
+  const currentOwner = context.payload.repository.owner.login;
+  const currentRepo = context.payload.repository.name;
+  const isCurrentRepository = owner.toLowerCase() === currentOwner.toLowerCase() && repo.toLowerCase() === currentRepo.toLowerCase();
+  if (!isCurrentRepository) {
+    const message =
+      `Cannot annotate comment from ${owner}/${repo}. ` +
+      `The comment URL must belong to the current repository ${currentOwner}/${currentRepo}; ` +
+      "comments outside the current organization or without installation access cannot be annotated.";
+    throw context.logger.error(message);
+  }
+
+  return match[1];
+}
+
+export async function commandHandler(context: Context<"issue_comment.created">) {
   if (!context.command) {
     return;
   }
@@ -57,12 +92,7 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
     const scope = context.command.parameters.scope ?? "org";
     let commentId = null;
     if (commentUrl) {
-      const commentRegex = /#issuecomment-(\d+)$/;
-      const match = commentUrl.match(commentRegex);
-      if (!match) {
-        throw logger.error("Invalid comment URL");
-      }
-      commentId = match[1];
+      commentId = parseCommentIdFromUrl(context, commentUrl);
     }
     await annotate(context, commentId, scope);
   }
@@ -87,12 +117,7 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
           throw logger.error("Invalid scope");
         }
 
-        const commentRegex = /#issuecomment-(\d+)$/;
-        const match = commentUrl.match(commentRegex);
-        if (!match) {
-          throw logger.error("Invalid comment URL");
-        }
-        commentId = match[1];
+        commentId = parseCommentIdFromUrl(context, commentUrl);
       } else {
         throw logger.error("Invalid parameters");
       }

--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -55,7 +55,11 @@ function parseCommentIdFromUrl(context: Context<"issue_comment.created">, commen
   try {
     parsedUrl = new URL(commentUrl);
   } catch {
-    return match[1];
+    // Preserve legacy fragment-only support for current-repository comments.
+    if (commentUrl.startsWith("/#issuecomment-")) {
+      return match[1];
+    }
+    throw context.logger.error("Invalid comment URL");
   }
 
   const hostname = parsedUrl.hostname.toLowerCase();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -640,6 +640,33 @@ describe("Plugin tests", () => {
     expect(updatedComment.body).not.toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
+  it("When a user annotates a comment URL outside the current repository, it should explain the permission boundary", async () => {
+    createIssue("Annotate target", "annotate", "Annotate Target", 22, { login: "test", id: 1 }, "open", null, STRINGS.TEST_REPO, STRINGS.USER_1);
+    const { context, errorSpy } = createContext(
+      "/annotate https://github.com/koya0/.ubiquity-os/issues/22#issuecomment-2535532258 repo",
+      1,
+      1,
+      2,
+      "outsideRepoAnnotate",
+      "annotate"
+    );
+    const getCommentMock = mock(async () => ({ data: annotateComment })) as unknown as typeof octokit.rest.issues.getComment;
+    context.octokit.rest.issues.getComment = getCommentMock;
+
+    let thrown: unknown;
+    try {
+      await runPlugin(context);
+    } catch (error) {
+      thrown = error;
+    }
+
+    const errorMessages = errorSpy.mock.calls.map(([message]) => String(message));
+    const errorText = [String(thrown), ...errorMessages].join("\n");
+    expect(errorText.includes("Cannot annotate comment from koya0/.ubiquity-os")).toBe(true);
+    expect(errorText.includes("outside the current organization")).toBe(true);
+    expect(getCommentMock).not.toHaveBeenCalled();
+  });
+
   function createContext(
     commentBody: string = "Hello, world!",
     repoId: number = 1,

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -667,6 +667,32 @@ describe("Plugin tests", () => {
     expect(getCommentMock).not.toHaveBeenCalled();
   });
 
+  it("When a user annotates a scheme-less GitHub URL, it should reject it as invalid", async () => {
+    createIssue("Annotate target", "annotate", "Annotate Target", 23, { login: "test", id: 1 }, "open", null, STRINGS.TEST_REPO, STRINGS.USER_1);
+    const { context, errorSpy } = createContext(
+      "/annotate github.com/ubiquity-os-marketplace/text-vector-embeddings/issues/23#issuecomment-2535532258 repo",
+      1,
+      1,
+      2,
+      "schemeLessAnnotate",
+      "annotate"
+    );
+    const getCommentMock = mock(async () => ({ data: annotateComment })) as unknown as typeof octokit.rest.issues.getComment;
+    context.octokit.rest.issues.getComment = getCommentMock;
+
+    let thrown: unknown;
+    try {
+      await runPlugin(context);
+    } catch (error) {
+      thrown = error;
+    }
+
+    const errorMessages = errorSpy.mock.calls.map(([message]) => String(message));
+    const errorText = [String(thrown), ...errorMessages].join("\n");
+    expect(errorText.includes("Invalid comment URL")).toBe(true);
+    expect(getCommentMock).not.toHaveBeenCalled();
+  });
+
   function createContext(
     commentBody: string = "Hello, world!",
     repoId: number = 1,


### PR DESCRIPTION
Resolves #78

## Summary
- Reject scheme-less GitHub comment URLs instead of treating them as fragment-only current-repository comments.
- Preserve the legacy /#issuecomment-123 shortcut for current-repository annotations.
- Add a regression test that keeps scheme-less URLs from reaching issues.getComment.

## Verification
- npx prettier --check src/handlers/user-annotate.ts tests/main.test.ts
- npx tsc --noEmit --pretty false (with a temporary local manifest.json placeholder because the repo generates manifest.json during prepare)