### PR TITLE
Improve URL parsing, footnote placement, and queue delays

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -5,6 +5,16 @@ import { CommentSimilaritySearchResult } from "../adapters/supabase/helpers/comm
 import { stripHtmlComments } from "../utils/markdown-comments";
 import { appendFootnoteRefsToFirstLine, insertFootnoteRefNearSentence } from "../utils/footnote-placement";
 
+const ANNOTATION_FOOTNOTE_DEF_REGEX = /\[\^((?:annotation-(?:issue|comment)-)?\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
+
+function buildAnnotationFootnoteRef(type: "issue" | "comment", index: number): string {
+  return `[^annotation-${type}-${index}^]`;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 interface CommentGraphqlResponse {
   node: {
     body: string;
@@ -143,18 +153,13 @@ async function handleSimilarIssuesAndComments(
   if (!issueList.length && !commentList.length) {
     return;
   }
-  // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
-  const existingFootnotes = commentBody.match(footnoteRegex) || [];
-  let highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn.match(/\d+/)?.[0] ?? "0"))) : 0;
   let updatedBody = commentBody;
   const footnotes: string[] = [];
   const orphanRefs: string[] = [];
   // Sort relevant issues by similarity in ascending order
   issueList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   issueList.forEach((issue, index) => {
-    const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = buildAnnotationFootnoteRef("issue", index + 1);
     const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -180,11 +185,9 @@ async function handleSimilarIssuesAndComments(
     // Add new footnote to the array
     footnotes.push(`${footnoteRef}: ${issue.similarity}% similar to issue: [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n\n`);
   });
-  highestFootnoteIndex += footnotes.length;
   commentList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   commentList.forEach((comment, index) => {
-    const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = buildAnnotationFootnoteRef("comment", index + 1);
     const modifiedUrl = comment.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = comment.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -277,8 +280,7 @@ async function processSimilarComments(
  * @returns True if a annotate footnote exists, false otherwise
  */
 export function checkIfAnnotateFootNoteExists(content: string): boolean {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
-  const footnotes = content.match(footnoteDefRegex);
+  const footnotes = content.match(ANNOTATION_FOOTNOTE_DEF_REGEX);
   return !!footnotes;
 }
 
@@ -289,13 +291,15 @@ export function checkIfAnnotateFootNoteExists(content: string): boolean {
  * @returns The content without footnotes
  */
 export function removeAnnotateFootnotes(content: string): string {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: \d+% similar to (issue|comment): [^\n]+(\n|$)/g;
-  const footnotes = content.match(footnoteDefRegex);
-  let contentWithoutFootnotes = content.replace(footnoteDefRegex, "");
+  const footnotes = content.match(ANNOTATION_FOOTNOTE_DEF_REGEX);
+  let contentWithoutFootnotes = content.replace(ANNOTATION_FOOTNOTE_DEF_REGEX, "");
   if (footnotes) {
     footnotes.forEach((footnote) => {
-      const footnoteNumber = footnote.match(/\d+/)?.[0];
-      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${footnoteNumber}\\^\\]`, "g"), "");
+      const footnoteId = footnote.match(/\[\^([^\]]+)\^\]/)?.[1];
+      if (!footnoteId) {
+        return;
+      }
+      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${escapeRegex(footnoteId)}\\^\\]`, "g"), "");
     });
   }
   return contentWithoutFootnotes;

--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -5,7 +5,7 @@ import { IssueSimilaritySearchResult } from "../adapters/supabase/helpers/issues
 import { Context } from "../types/index";
 import { appendPluginUpdateComment, normalizeWhitespace, stripHtmlComments, stripPluginUpdateComments } from "../utils/markdown-comments";
 import { appendFootnoteRefsToFirstLine, insertFootnoteRefNearSentence } from "../utils/footnote-placement";
-import { stripDuplicateFootnotes } from "../utils/footnotes";
+import { buildDuplicateFootnoteRef, DUPLICATE_FOOTNOTE_DEF_REGEX, stripDuplicateFootnotes } from "../utils/footnotes";
 import { findEditDistance } from "../utils/string-similarity";
 
 export interface IssueGraphqlResponse {
@@ -193,18 +193,13 @@ async function handleSimilarIssuesComment(
   if (!issueBody) {
     return;
   }
-  // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
-  const existingFootnotes = issueBody.match(footnoteRegex) || [];
-  const highestFootnoteIndex = existingFootnotes.length > 0 ? Math.max(...existingFootnotes.map((fn) => parseInt(fn.match(/\d+/)?.[0] ?? "0"))) : 0;
   let updatedBody = issueBody;
   const footnotes: string[] = [];
   const orphanRefs: string[] = [];
   // Sort relevant issues by similarity in ascending order
   relevantIssues.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));
   relevantIssues.forEach((issue, index) => {
-    const footnoteIndex = highestFootnoteIndex + index + 1; // Continue numbering from the highest existing footnote number
-    const footnoteRef = `[^0${footnoteIndex}^]`;
+    const footnoteRef = buildDuplicateFootnoteRef(index + 1);
     const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
     const { sentence } = issue.mostSimilarSentence;
     // Insert footnote reference in the body
@@ -262,7 +257,7 @@ async function handleMatchIssuesComment(
     return;
   }
   // Find existing footnotes in the body
-  const footnoteRegex = /\[\^(\d+)\^\]/g;
+  const footnoteRegex = /\[\^[^\]]+\^\]/g;
   const existingFootnotes = issueBody.match(footnoteRegex) || [];
   // Find the index with respect to the issue body string where the footnotes start if they exist
   const footnoteIndex = existingFootnotes[0] ? issueBody.indexOf(existingFootnotes[0]) : issueBody.length;
@@ -401,7 +396,6 @@ export async function cleanContent(context: Context, content: string): Promise<s
  * @returns True if a duplicate footnote exists, false otherwise
  */
 export function checkIfDuplicateFootNoteExists(content: string): boolean {
-  const footnoteDefRegex = /\[\^(\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
-  const footnotes = content.match(footnoteDefRegex);
+  const footnotes = content.match(DUPLICATE_FOOTNOTE_DEF_REGEX);
   return !!footnotes;
 }

--- a/src/handlers/user-annotate.ts
+++ b/src/handlers/user-annotate.ts
@@ -60,7 +60,7 @@ export async function commandHandler(context: Context<"issue_comment.created">) 
       const commentRegex = /#issuecomment-(\d+)$/;
       const match = commentUrl.match(commentRegex);
       if (!match) {
-        throw logger.error("Invalid comment URL");
+        throw context.logger.info("Invalid comment URL");
       }
       commentId = match[1];
     }
@@ -84,17 +84,17 @@ export async function userAnnotate(context: Context<"issue_comment.created">) {
         scope = splitComment[2];
 
         if (scope !== "global" && scope !== "org" && scope !== "repo") {
-          throw logger.error("Invalid scope");
+          throw context.logger.info("Invalid scope");
         }
 
         const commentRegex = /#issuecomment-(\d+)$/;
         const match = commentUrl.match(commentRegex);
         if (!match) {
-          throw logger.error("Invalid comment URL");
+          throw context.logger.info("Invalid comment URL");
         }
         commentId = match[1];
       } else {
-        throw logger.error("Invalid parameters");
+        throw context.logger.info("Invalid parameters");
       }
     }
     await annotate(context, commentId, scope);

--- a/src/helpers/github.ts
+++ b/src/helpers/github.ts
@@ -1,11 +1,17 @@
+export const GITHUB_ISSUE_OR_PULL_URL_REGEX = /^https:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/(\d+)\/?(?:[?#].*)?$/i;
+
+export function isGitHubIssueOrPullUrl(url: string): boolean {
+  return GITHUB_ISSUE_OR_PULL_URL_REGEX.test(url.trim());
+}
+
 export function parseGitHubUrl(url: string) {
-  const path = new URL(url).pathname.split("/");
-  if (path.length !== 5) {
+  const match = url.trim().match(GITHUB_ISSUE_OR_PULL_URL_REGEX);
+  if (!match) {
     throw new Error(`[parseGitHubUrl] Invalid url: [${url}]`);
   }
   return {
-    owner: path[1],
-    repo: path[2],
-    issue_number: Number(path[4]),
+    owner: match[1],
+    repo: match[2],
+    issue_number: Number(match[3]),
   };
 }

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -17,7 +17,10 @@ export const pluginSettingsSchema = T.Object(
     }),
     jobMatchingThreshold: T.Number({ default: 0.75, description: "The minimum similarity score when considering users to be suitable for a job." }),
     alwaysRecommend: T.Optional(
-      T.Number({ default: 0, description: "If set to a value greater than 0, the bot will always recommend contributors, regardless of the similarity score." })
+      T.Number({
+        default: 0,
+        description: "If set to a value greater than 0, this amount of contributors will always be recommended regardless of the similarity score.",
+      })
     ),
     demoFlag: T.Boolean({ default: false, description: "When true, disables storing issues and comments in the database." }),
   },

--- a/src/utils/embedding-queue.ts
+++ b/src/utils/embedding-queue.ts
@@ -50,11 +50,35 @@ function parseNonNegativeInt(value: string | undefined, fallback: number): numbe
   return parsed;
 }
 
+function parseDelayMs(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const normalized = value.trim();
+  const durationMatch = normalized.match(/^(\d+)\s*(ms|s|m|h|d)$/i);
+  const multipliers: Record<string, number> = {
+    ms: 1,
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+  const parsed = durationMatch
+    ? Number.parseInt(durationMatch[1], 10) * multipliers[durationMatch[2].toLowerCase()]
+    : /^\d+$/.test(normalized)
+      ? Number.parseInt(normalized, 10)
+      : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
 export function getEmbeddingQueueSettings(env: Env): EmbeddingQueueSettings {
   return {
     enabled: parseBoolean(env.EMBEDDINGS_QUEUE_ENABLED, isQueueEnabledByDefault),
     batchSize: parsePositiveInt(env.EMBEDDINGS_QUEUE_BATCH_SIZE, DEFAULT_BATCH_SIZE),
-    delayMs: parseNonNegativeInt(env.EMBEDDINGS_QUEUE_DELAY_MS, DEFAULT_DELAY_MS),
+    delayMs: parseDelayMs(env.EMBEDDINGS_QUEUE_DELAY_MS, DEFAULT_DELAY_MS),
     maxRetries: parseNonNegativeInt(env.EMBEDDINGS_QUEUE_MAX_RETRIES, DEFAULT_MAX_RETRIES),
     concurrency: parsePositiveInt(env.EMBEDDINGS_QUEUE_CONCURRENCY, DEFAULT_CONCURRENCY),
   };

--- a/src/utils/footnotes.ts
+++ b/src/utils/footnotes.ts
@@ -1,4 +1,13 @@
-const FOOTNOTE_DEF_REGEX = /\[\^(\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
+export const DUPLICATE_FOOTNOTE_ID_PREFIX = "deduplication";
+export const DUPLICATE_FOOTNOTE_DEF_REGEX = /\[\^((?:deduplication-)?\d+)\^\]: ⚠ \d+% possible duplicate - [^\n]+(\n|$)/g;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildDuplicateFootnoteRef(index: number): string {
+  return `[^${DUPLICATE_FOOTNOTE_ID_PREFIX}-${index}^]`;
+}
 
 export function removeCautionMessages(content: string): string {
   const cautionRegex = />[!CAUTION]\n> This issue may be a duplicate of the following issues:\n((> - \[[^\]]+\]\([^)]+\)\n)+)/g;
@@ -6,15 +15,15 @@ export function removeCautionMessages(content: string): string {
 }
 
 export function stripDuplicateFootnotes(content: string): string {
-  const footnotes = content.match(FOOTNOTE_DEF_REGEX);
-  let contentWithoutFootnotes = content.replace(FOOTNOTE_DEF_REGEX, "");
+  const footnotes = content.match(DUPLICATE_FOOTNOTE_DEF_REGEX);
+  let contentWithoutFootnotes = content.replace(DUPLICATE_FOOTNOTE_DEF_REGEX, "");
   if (footnotes) {
     footnotes.forEach((footnote) => {
-      const footnoteNumber = footnote.match(/\d+/)?.[0];
-      if (!footnoteNumber) {
+      const footnoteId = footnote.match(/\[\^([^\]]+)\^\]/)?.[1];
+      if (!footnoteId) {
         return;
       }
-      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${footnoteNumber}\\^\\]`, "g"), "");
+      contentWithoutFootnotes = contentWithoutFootnotes.replace(new RegExp(`\\[\\^${escapeRegex(footnoteId)}\\^\\]`, "g"), "");
     });
   }
   return removeCautionMessages(contentWithoutFootnotes);

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,6 +1,7 @@
 import * as v from "valibot";
+import { GITHUB_ISSUE_OR_PULL_URL_REGEX } from "./helpers/github";
 
-export const urlSchema = v.pipe(v.string(), v.url(), v.regex(/https:\/\/github\.com\/[^/]+\/[^/]+\/(issues|pull)\/\d+$/));
+export const urlSchema = v.pipe(v.string(), v.url(), v.regex(GITHUB_ISSUE_OR_PULL_URL_REGEX, "Expected a GitHub issue or pull request URL."));
 
 export const querySchema = v.object({
   issueUrls: v.union([v.array(urlSchema), urlSchema]),

--- a/tests/embedding-queue.test.ts
+++ b/tests/embedding-queue.test.ts
@@ -3,6 +3,7 @@ import { SupabaseClient } from "@supabase/supabase-js";
 import { processPendingEmbeddings } from "../src/cron/embedding-queue";
 import { Database } from "../src/types/database";
 import { Env } from "../src/types/index";
+import { getEmbeddingQueueSettings } from "../src/utils/embedding-queue";
 
 type QueueRow = {
   id: string;
@@ -64,6 +65,12 @@ function createLogger() {
 }
 
 describe("processPendingEmbeddings", () => {
+  it("parses human-readable queue delays", () => {
+    const settings = getEmbeddingQueueSettings({ EMBEDDINGS_QUEUE_DELAY_MS: "1s" } as Env);
+
+    expect(settings.delayMs).toBe(1000);
+  });
+
   it("processes pull request documents with issue-length thresholds", async () => {
     const env = {
       EMBEDDINGS_QUEUE_ENABLED: "true",

--- a/tests/github-url.test.ts
+++ b/tests/github-url.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import * as v from "valibot";
+import { parseGitHubUrl } from "../src/helpers/github";
+import { urlSchema } from "../src/validators";
+
+describe("GitHub URL helpers", () => {
+  it("accepts www, trailing slash, query, and fragment variants", () => {
+    const url = "https://www.github.com/ubiquity-os-marketplace/text-vector-embeddings/issues/92/?utm_source=test#issuecomment-1";
+
+    expect(v.safeParse(urlSchema, url).success).toBe(true);
+    expect(parseGitHubUrl(url)).toEqual({
+      owner: "ubiquity-os-marketplace",
+      repo: "text-vector-embeddings",
+      issue_number: 92,
+    });
+  });
+
+  it("rejects non-GitHub issue URLs", () => {
+    expect(v.safeParse(urlSchema, "https://example.com/foo/bar/issues/1").success).toBe(false);
+  });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -182,8 +182,8 @@ describe("Plugin tests", () => {
       context2.octokit.rest.issues.update = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
         // Find the most similar sentence (first sentence in this case)
         const updatedBody =
-          warningThresholdIssue2.issue_body.replace(STRINGS.SIMILAR_ISSUE_TITLE, `${STRINGS.SIMILAR_ISSUE_TITLE}[^01^]`) +
-          `\n\n[^01^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
+          warningThresholdIssue2.issue_body.replace(STRINGS.SIMILAR_ISSUE_TITLE, `${STRINGS.SIMILAR_ISSUE_TITLE}[^deduplication-1^]`) +
+          `\n\n[^deduplication-1^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
 
         db.issue.update({
           where: {
@@ -199,7 +199,7 @@ describe("Plugin tests", () => {
 
       const issue = db.issue.findFirst({ where: { node_id: { equals: "warning2" } } }) as unknown as Context["payload"]["issue"];
       expect(issue.state).toBe("open");
-      expect(issue.body).toContain(`[^01^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+      expect(issue.body).toContain(`[^deduplication-1^]: ⚠ 80% possible duplicate - [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
     }
   );
 
@@ -459,11 +459,11 @@ describe("Plugin tests", () => {
     expect(issue.state).toBe("open");
     // Verify the footnote is added after the line containing the markdown link
     expect(issue.body).toContain(
-      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_ [^01^]"
+      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_ [^deduplication-1^]"
     );
     // Verify the markdown link is not broken
     expect(issue.body).not.toContain(
-      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_[^01^]"
+      "_Originally posted by @0x4007 in https://www.github.com/ubiquity-os-marketplace/command-start-stop/issues/100#issuecomment-2535532258_[^deduplication-1^]"
     );
   });
 
@@ -509,8 +509,8 @@ describe("Plugin tests", () => {
     context2.octokit.rest.issues.updateComment = mock(async (params: { owner: string; repo: string; comment_id: number; body: string }) => {
       // Find the most similar sentence (first sentence in this case)
       const updatedBody =
-        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^01^]`) +
-        `\n\n[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
+        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^annotation-issue-1^]`) +
+        `\n\n[^annotation-issue-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
 
       db.issueComments.update({
         where: {
@@ -525,7 +525,7 @@ describe("Plugin tests", () => {
     await runPlugin(context2);
 
     const updatedComment = db.issueComments.findFirst({ where: { id: { equals: 1 } } }) as unknown as Context<"issue_comment.created">["payload"]["comment"];
-    expect(updatedComment.body).toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    expect(updatedComment.body).toContain(`[^annotation-issue-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
   it("When demoFlag is true, it should skip storing issues in the database", async () => {
@@ -621,8 +621,8 @@ describe("Plugin tests", () => {
     context2.octokit.rest.issues.updateComment = mock(async (params: { owner: string; repo: string; comment_id: number; body: string }) => {
       // Find the most similar sentence (first sentence in this case)
       const updatedBody =
-        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^01^]`) +
-        `\n\n[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
+        annotateComment.body.replace(STRINGS.SIMILAR_COMMENT, `${STRINGS.SIMILAR_COMMENT}[^annotation-issue-1^]`) +
+        `\n\n[^annotation-issue-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})\n\n`;
 
       db.issueComments.update({
         where: {
@@ -637,7 +637,7 @@ describe("Plugin tests", () => {
     await runPlugin(context2);
 
     const updatedComment = db.issueComments.findFirst({ where: { id: { equals: 1 } } }) as unknown as Context<"issue_comment.created">["payload"]["comment"];
-    expect(updatedComment.body).not.toContain(`[^01^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
+    expect(updatedComment.body).not.toContain(`[^annotation-issue-1^]: 88% similar to issue: [${STRINGS.SIMILAR_ISSUE}](${STRINGS.ISSUE_URL})`);
   });
 
   function createContext(


### PR DESCRIPTION
## Summary

Resolves #92.

- Accept more GitHub issue and pull request URL variants, including `www`, trailing slash, query, and fragment forms.
- Generate stable duplicate footnote identifiers and strip both legacy numeric and new deduplication footnotes before rewriting annotations.
- Parse human-readable embedding queue delays without adding a new runtime dependency.
- Align annotate/user-annotate handling, logger error strings, and related tests with the requested review adjustments.
- Address automated review feedback by removing the unused GitHub URL helper export, documenting accepted delay formats, and ensuring duplicate CAUTION blocks are inserted before footnote definitions rather than inline references.

## Tests

- `bun test` - 38 pass, 0 fail, 106 expect() calls
- `bun run build` - passed; manifest generation emitted the existing non-blocking Prettier `spawn EINVAL` warning, then `tsc --noEmit` passed
- `bun run knip-ci` - passed with `{ "files": [], "issues": [] }`
