### PR TITLE
fix: rank recommendations by contextual score

### DIFF
--- a/src/handlers/issue-matching.ts
+++ b/src/handlers/issue-matching.ts
@@ -8,6 +8,9 @@ export interface IssueGraphqlResponse {
     state: string;
     stateReason: string;
     closed: boolean;
+    createdAt?: string | null;
+    updatedAt?: string | null;
+    closedAt?: string | null;
     repository: {
       owner: {
         login: string;
@@ -24,6 +27,13 @@ export interface IssueGraphqlResponse {
   similarity: number;
 }
 
+type RepositoryContext = {
+  owner: {
+    login: string;
+  };
+  name: string;
+};
+
 type IssueNodeResponse = IssueGraphqlResponse | { node: null };
 
 type IssueCommentSummary = {
@@ -31,8 +41,73 @@ type IssueCommentSummary = {
   body?: string | null;
 };
 
+const SAME_REPOSITORY_MULTIPLIER = 1;
+const SAME_ORGANIZATION_MULTIPLIER = 0.75;
+const GLOBAL_MULTIPLIER = 0.5;
+const MAX_RECENCY_AGE_DAYS = 365 * 2;
+
 function hasIssueNode(response: IssueNodeResponse): response is IssueGraphqlResponse {
   return response.node !== null;
+}
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(1, score));
+}
+
+function getRepositoryContextMultiplier(issue: IssueGraphqlResponse, repository: RepositoryContext) {
+  const isSameOwner = issue.node.repository.owner.login === repository.owner.login;
+  const isSameRepository = isSameOwner && issue.node.repository.name === repository.name;
+
+  if (isSameRepository) {
+    return SAME_REPOSITORY_MULTIPLIER;
+  }
+  if (isSameOwner) {
+    return SAME_ORGANIZATION_MULTIPLIER;
+  }
+  return GLOBAL_MULTIPLIER;
+}
+
+function getRecencyMultiplier(issue: IssueGraphqlResponse) {
+  const timestamp = issue.node.closedAt ?? issue.node.updatedAt ?? issue.node.createdAt;
+  if (!timestamp) {
+    return 1;
+  }
+
+  const updatedAt = new Date(timestamp).getTime();
+  if (Number.isNaN(updatedAt)) {
+    return 1;
+  }
+
+  const ageDays = Math.max(0, (Date.now() - updatedAt) / (24 * 60 * 60 * 1000));
+  return Math.max(0.5, 1 - ageDays / MAX_RECENCY_AGE_DAYS);
+}
+
+function getCompletionMultiplier(issue: IssueGraphqlResponse) {
+  if (issue.node.closed && issue.node.stateReason === "COMPLETED") {
+    return 1;
+  }
+  if (issue.node.closed) {
+    return 0.75;
+  }
+  return 0.6;
+}
+
+function getAssignmentQualityMultiplier(issue: IssueGraphqlResponse) {
+  const assigneeCount = issue.node.assignees.nodes.length;
+  if (assigneeCount <= 1) {
+    return 1;
+  }
+  return Math.max(0.85, 1 - (assigneeCount - 1) * 0.05);
+}
+
+function calculateRecommendationScore(issue: IssueGraphqlResponse, repository: RepositoryContext) {
+  return clampScore(
+    issue.similarity *
+      getRepositoryContextMultiplier(issue, repository) *
+      getRecencyMultiplier(issue) *
+      getCompletionMultiplier(issue) *
+      getAssignmentQualityMultiplier(issue)
+  );
 }
 
 export async function issueMatchingWithComment(context: Context<"issues.opened" | "issues.edited" | "issues.labeled">) {
@@ -149,10 +224,11 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
   // If alwaysRecommend is enabled, use a lower threshold to ensure we get enough recommendations
   const threshold =
     options.forceThresholdZero || (context.config.alwaysRecommend && context.config.alwaysRecommend > 0) ? 0 : context.config.jobMatchingThreshold;
+  const searchThreshold = threshold > 0 ? threshold * GLOBAL_MULTIPLIER : threshold;
 
   const similarIssues = await supabase.issue.findSimilarIssuesToMatch({
     markdown: issueContent,
-    threshold: threshold,
+    threshold: searchThreshold,
     currentId: issue.node_id,
     topK: options.topK,
   });
@@ -178,6 +254,9 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
                   }
                   stateReason
                   closed
+                  createdAt
+                  updatedAt
+                  closedAt
                   assignees(first: 10) {
                     nodes {
                       login
@@ -204,6 +283,7 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
     const issueList = await Promise.allSettled(fetchPromises);
 
     logger.debug("Fetched similar issues", { issueList });
+    const contributorScores: Map<string, number[]> = new Map();
     issueList.forEach((issuePromise: PromiseSettledResult<IssueGraphqlResponse | null>) => {
       if (!issuePromise || issuePromise.status === "rejected" || !issuePromise.value) {
         return;
@@ -219,8 +299,11 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
           if (options.allowedLogins && !options.allowedLogins.has(assignee.login)) {
             return;
           }
-          const similarityPercentage = Math.round(issue.similarity * 100);
+          const similarityPercentage = Math.round(calculateRecommendationScore(issue, payload.repository) * 100);
           const issueLink = issue.node.url.replace(/https?:\/\/github.com/, "https://www.github.com");
+          const scores = contributorScores.get(assignee.login) ?? [];
+          scores.push(similarityPercentage);
+          contributorScores.set(assignee.login, scores);
           if (matchResultArray.has(assignee.login)) {
             matchResultArray
               .get(assignee.login)
@@ -251,9 +334,9 @@ async function issueMatchingInternal(context: Context<IssueMatchingEvents>, opti
       .map(([login, matches]) => ({
         login,
         matches,
-        maxSimilarity: matches.length ? Math.max(...matches.map((match) => parseInt(match.match(/`(\d+)% Match`/)?.[1] || "0"))) : 0,
+        maxSimilarity: contributorScores.get(login)?.length ? Math.max(...(contributorScores.get(login) ?? [])) : 0,
       }))
-      .sort((a, b) => b.maxSimilarity - a.maxSimilarity);
+      .sort((a, b) => b.maxSimilarity - a.maxSimilarity || b.matches.length - a.matches.length);
 
     logger.debug("Sorted contributors", { sortedContributors });
     return { matchResultArray, similarIssues, sortedContributors };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -329,6 +329,63 @@ describe("Plugin tests", () => {
     expect(comments[0].body).toContain("98% Match");
   });
 
+  it("When issue matching has same-repo and global matches, it ranks same-repo combined score first", async () => {
+    const sameRepoIssueId = "same-repo-match";
+    const { context } = createContextIssues(DEFAULT_BODY, "context_scored", 10, "Fix webhook delivery retry");
+    context.eventName = ISSUES_EDITED_EVENT_NAME;
+
+    context.adapters.supabase.issue.findSimilarIssuesToMatch = mock().mockResolvedValue([
+      { id: "global-match", issue_id: "global-match", similarity: 0.95 },
+      { id: sameRepoIssueId, issue_id: sameRepoIssueId, similarity: 0.8 },
+    ] as IssueSimilaritySearchResult[]);
+
+    context.adapters.supabase.issue.createIssue = mock(async () => {
+      createIssue(DEFAULT_BODY, "context_scored", "Fix webhook delivery retry", 10, { login: "test", id: 1 }, "open", null, STRINGS.TEST_REPO, STRINGS.USER_1);
+    });
+
+    context.octokit.graphql = mock(async (query: string, variables: { issueNodeId: string }) => {
+      void query;
+      const isSameRepo = variables.issueNodeId === sameRepoIssueId;
+      return {
+        node: {
+          title: isSameRepo ? "Same repo delivery retry" : "Global webhook retry",
+          url: isSameRepo ? "https://github.com/ubiquity/test-repo/issues/11" : "https://github.com/other-org/other-repo/issues/12",
+          state: "closed",
+          stateReason: "COMPLETED",
+          closed: true,
+          repository: {
+            owner: { login: isSameRepo ? STRINGS.USER_1 : "other-org" },
+            name: isSameRepo ? STRINGS.TEST_REPO : "other-repo",
+          },
+          assignees: {
+            nodes: [
+              {
+                login: isSameRepo ? "same-repo-dev" : "global-dev",
+                url: isSameRepo ? "https://github.com/same-repo-dev" : "https://github.com/global-dev",
+              },
+            ],
+          },
+        },
+      };
+    }) as unknown as typeof context.octokit.graphql;
+
+    context.octokit.rest.issues.createComment = mock(async (params: { owner: string; repo: string; issue_number: number; body: string }) => {
+      createComment(params.body, 10, "context_scored", params.issue_number);
+    }) as unknown as typeof octokit.rest.issues.createComment;
+
+    await runPlugin(context);
+
+    const comments = db.issueComments.findMany({ where: { node_id: { equals: "context_scored" } } });
+    expect(comments.length).toBe(1);
+    const sameRepoIndex = comments[0].body.indexOf("same-repo-dev");
+    const globalIndex = comments[0].body.indexOf("global-dev");
+    expect(sameRepoIndex).toBeGreaterThan(-1);
+    expect(globalIndex).toBeGreaterThan(-1);
+    expect(sameRepoIndex).toBeLessThan(globalIndex);
+    expect(comments[0].body).toContain("80% Match");
+    expect(comments[0].body).toContain("48% Match");
+  });
+
   it("When issue matching is triggered with alwaysRecommend enabled, it should suggest contributors regardless of similarity", async () => {
     const [taskCompleteIssue] = fetchSimilarIssues("task_complete");
     const { context } = createContextIssues(taskCompleteIssue.issue_body, "task_complete_always", 6, taskCompleteIssue.title);


### PR DESCRIPTION
Resolves #55

## Summary
- apply same-repository, same-organization, and global context multipliers to issue-matching recommendation scores
- include recency, completion state, and assignee quality in contributor ranking while keeping global fallback candidates discoverable
- rank contributors by the combined score and cover same-repo matches outranking stronger global similarity matches

## Tests
- bun test
- bun run build
- focused Prettier, ESLint, and cspell checks on the changed files
- git diff --check