### PR TITLE
fix invalid hash fragments in issue footnotes

### DIFF
--- a/src/handlers/annotate.ts
+++ b/src/handlers/annotate.ts
@@ -178,7 +178,7 @@ async function handleSimilarIssuesAndComments(
     }
 
     // Add new footnote to the array
-    footnotes.push(`${footnoteRef}: ${issue.similarity}% similar to issue: [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n\n`);
+    footnotes.push(`${footnoteRef}: ${issue.similarity}% similar to issue: [${issue.node.title}](${modifiedUrl})\n\n`);
   });
   highestFootnoteIndex += footnotes.length;
   commentList.sort((a, b) => parseFloat(a.similarity) - parseFloat(b.similarity));

--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -228,7 +228,7 @@ async function handleSimilarIssuesComment(
     }
 
     // Add new footnote to the array
-    footnotes.push(`${footnoteRef}: ⚠ ${issue.similarity}% possible duplicate - [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n\n`);
+    footnotes.push(`${footnoteRef}: ⚠ ${issue.similarity}% possible duplicate - [${issue.node.title}](${modifiedUrl})\n\n`);
   });
   if (orphanRefs.length > 0) {
     updatedBody = appendFootnoteRefsToFirstLine(updatedBody, orphanRefs);
@@ -272,7 +272,7 @@ async function handleMatchIssuesComment(
   // Append the similar issues to the resultBuilder
   relevantIssues.forEach((issue) => {
     const modifiedUrl = issue.node.url.replace("https://github.com", "https://www.github.com");
-    resultBuilder += `> - [${issue.node.title}](${modifiedUrl}#${issue.node.number})\n`;
+    resultBuilder += `> - [${issue.node.title}](${modifiedUrl})\n`;
   });
   // Insert the resultBuilder into the issue body
   // Update the issue with the modified body


### PR DESCRIPTION
Resolves #93

removes invalid issue number fragments from issue footnote links. github issue urls already point to the issue, so fragments like #25 are invalid.

comment footnote urls are left unchanged because they already include issuecomment anchors.

tests not run locally.